### PR TITLE
新增LSP功能

### DIFF
--- a/extension/Resources/4GLKeywords.json
+++ b/extension/Resources/4GLKeywords.json
@@ -1,0 +1,1352 @@
+[
+  {
+    "name": "ABSOLUTE",
+    "type": "keyword"
+  },
+  {
+    "name": "ACCELERATOR"
+  },
+  {
+    "name": "ACCEPT"
+  },
+  {
+    "name": "ACCESSORYTYPE"
+  },
+  {
+    "name": "ACTION"
+  },
+  {
+    "name": "ADD"
+  },
+  {
+    "name": "AFTER"
+  },
+  {
+    "name": "ALL"
+  },
+  {
+    "name": "ALTER"
+  },
+  {
+    "name": "AND"
+  },
+  {
+    "name": "ANSI"
+  },
+  {
+    "name": "ANY"
+  },
+  {
+    "name": "APPEND"
+  },
+  {
+    "name": "APPLICATION"
+  },
+  {
+    "name": "ARG_VAL"
+  },
+  {
+    "name": "ARRAY",
+    "type": "keyword"
+  },
+  {
+    "name": "AS"
+  },
+  {
+    "name": "ASC"
+  },
+  {
+    "name": "ASCENDING"
+  },
+  {
+    "name": "ASCII"
+  },
+  {
+    "name": "AT"
+  },
+  {
+    "name": "ATTRIBUTE"
+  },
+  {
+    "name": "ATTRIBUTES"
+  },
+  {
+    "name": "AUDIT"
+  },
+  {
+    "name": "AUTHORIZATION"
+  },
+  {
+    "name": "AUTO"
+  },
+  {
+    "name": "AVG"
+  },
+  {
+    "name": "BEFORE"
+  },
+  {
+    "name": "BEGIN"
+  },
+  {
+    "name": "BETWEEN"
+  },
+  {
+    "name": "BIGINT",
+    "type": "keyword"
+  },
+  {
+    "name": "BIGSERIAL"
+  },
+  {
+    "name": "BLACK",
+    "type": "color"
+  },
+  {
+    "name": "BLINK"
+  },
+  {
+    "name": "BLUE",
+    "type": "color"
+  },
+  {
+    "name": "BOLD"
+  },
+  {
+    "name": "BOOLEAN",
+    "type": "keyword"
+  },
+  {
+    "name": "BORDER"
+  },
+  {
+    "name": "BOTTOM"
+  },
+  {
+    "name": "BREAKPOINT"
+  },
+  {
+    "name": "BUFFER"
+  },
+  {
+    "name": "BUFFERED"
+  },
+  {
+    "name": "BY"
+  },
+  {
+    "name": "BYTE",
+    "type": "keyword"
+  },
+  {
+    "name": "CACHE"
+  },
+  {
+    "name": "CALL"
+  },
+  {
+    "name": "CANCEL"
+  },
+  {
+    "name": "CASCADE"
+  },
+  {
+    "name": "CASE"
+  },
+  {
+    "name": "CAST"
+  },
+  {
+    "name": "CATCH"
+  },
+  {
+    "name": "CENTURY"
+  },
+  {
+    "name": "CHANGE"
+  },
+  {
+    "name": "CHAR",
+    "type": "keyword"
+  },
+  {
+    "name": "CHARACTER",
+    "type": "keyword"
+  },
+  {
+    "name": "CHECK"
+  },
+  {
+    "name": "CHECKMARK"
+  },
+  {
+    "name": "CIRCUIT"
+  },
+  {
+    "name": "CLEAR"
+  },
+  {
+    "name": "CLIPPED"
+  },
+  {
+    "name": "CLOSE"
+  },
+  {
+    "name": "CLUSTER"
+  },
+  {
+    "name": "COLLAPSE"
+  },
+  {
+    "name": "COLUMN"
+  },
+  {
+    "name": "COLUMNS"
+  },
+  {
+    "name": "COMMAND"
+  },
+  {
+    "name": "COMMENT"
+  },
+  {
+    "name": "COMMIT"
+  },
+  {
+    "name": "COMMITTED"
+  },
+  {
+    "name": "CONCURRENT"
+  },
+  {
+    "name": "CONNECT"
+  },
+  {
+    "name": "CONNECTION"
+  },
+  {
+    "name": "CONSTANT",
+    "type": "keyword",
+    "description": "The CONSTANT instruction defines a program constant.",
+    "documentation": "https://4js.com/online_documentation/fjs-fgl-manual-html/#fgl-topics/c_fgl_Constants_003.html"
+  },
+  {
+    "name": "CONSTRAINED"
+  },
+  {
+    "name": "CONSTRAINT"
+  },
+  {
+    "name": "CONSTRUCT"
+  },
+  {
+    "name": "CONTEXTMENU"
+  },
+  {
+    "name": "CONTINUE"
+  },
+  {
+    "name": "CONTROL"
+  },
+  {
+    "name": "COUNT"
+  },
+  {
+    "name": "CREATE"
+  },
+  {
+    "name": "CROSS"
+  },
+  {
+    "name": "CURRENT"
+  },
+  {
+    "name": "CURSOR"
+  },
+  {
+    "name": "CYAN",
+    "type": "color"
+  },
+  {
+    "name": "CYCLE"
+  },
+  {
+    "name": "DATABASE",
+    "type": "keyword",
+    "description": "Opens a new database connection in unique-session mode.",
+    "documentation": "https://4js.com/online_documentation/fjs-fgl-manual-html/#fgl-topics/c_fgl_Connections_040.html"
+  },
+  {
+    "name": "DATE"
+  },
+  {
+    "name": "DATETIME"
+  },
+  {
+    "name": "DAY"
+  },
+  {
+    "name": "DBA"
+  },
+  {
+    "name": "DBSERVERNAME"
+  },
+  {
+    "name": "DEC",
+    "type": "keyword"
+  },
+  {
+    "name": "DECIMAL",
+    "type": "keyword"
+  },
+  {
+    "name": "DECLARE"
+  },
+  {
+    "name": "DEFAULT"
+  },
+  {
+    "name": "DEFAULTS"
+  },
+  {
+    "name": "DEFAULTVIEW"
+  },
+  {
+    "name": "DEFER"
+  },
+  {
+    "name": "DEFINE",
+    "type": "keyword",
+    "description": "A variable contains volatile information of a specific data type.",
+    "documentation": "https://4js.com/online_documentation/fjs-fgl-manual-html/#fgl-topics/c_fgl_variables_DEFINE.html"
+  },
+  {
+    "name": "DELETE"
+  },
+  {
+    "name": "DELIMITER"
+  },
+  {
+    "name": "DESC"
+  },
+  {
+    "name": "DESCENDING"
+  },
+  {
+    "name": "DESCRIBE"
+  },
+  {
+    "name": "DESTINATION"
+  },
+  {
+    "name": "DETAILACTION"
+  },
+  {
+    "name": "DETAILBUTTON"
+  },
+  {
+    "name": "DIALOG"
+  },
+  {
+    "name": "DICTIONARY"
+  },
+  {
+    "name": "DIM"
+  },
+  {
+    "name": "DIMENSION"
+  },
+  {
+    "name": "DIRTY"
+  },
+  {
+    "name": "DISCLOSUREINDICATOR"
+  },
+  {
+    "name": "DISCONNECT"
+  },
+  {
+    "name": "DISPLAY"
+  },
+  {
+    "name": "DISTINCT"
+  },
+  {
+    "name": "DORMANT"
+  },
+  {
+    "name": "DOUBLE",
+    "type": "keyword"
+  },
+  {
+    "name": "DOUBLECLICK"
+  },
+  {
+    "name": "DOWN"
+  },
+  {
+    "name": "DRAG_ENTER"
+  },
+  {
+    "name": "DRAG_FINISHED"
+  },
+  {
+    "name": "DRAG_OVER"
+  },
+  {
+    "name": "DRAG_START"
+  },
+  {
+    "name": "DROP"
+  },
+  {
+    "name": "DYNAMIC",
+    "type": "keyword"
+  },
+  {
+    "name": "ELSE"
+  },
+  {
+    "name": "END"
+  },
+  {
+    "name": "ERROR"
+  },
+  {
+    "name": "ESCAPE"
+  },
+  {
+    "name": "EVERY"
+  },
+  {
+    "name": "EXCLUSIVE"
+  },
+  {
+    "name": "EXECUTE"
+  },
+  {
+    "name": "EXISTS"
+  },
+  {
+    "name": "EXIT"
+  },
+  {
+    "name": "EXPAND"
+  },
+  {
+    "name": "EXPLAIN"
+  },
+  {
+    "name": "EXTEND"
+  },
+  {
+    "name": "EXTENT"
+  },
+  {
+    "name": "EXTERNAL"
+  },
+  {
+    "name": "FALSE",
+    "type": "constant"
+  },
+  {
+    "name": "FETCH"
+  },
+  {
+    "name": "FGL"
+  },
+  {
+    "name": "FGL_DRAWBOX"
+  },
+  {
+    "name": "FIELD"
+  },
+  {
+    "name": "FIELD_TOUCHED"
+  },
+  {
+    "name": "FILE"
+  },
+  {
+    "name": "FILL"
+  },
+  {
+    "name": "FINISH"
+  },
+  {
+    "name": "FIRST"
+  },
+  {
+    "name": "FLOAT",
+    "type": "keyword"
+  },
+  {
+    "name": "FLUSH"
+  },
+  {
+    "name": "FOCUSONFIELD"
+  },
+  {
+    "name": "FOR"
+  },
+  {
+    "name": "FOREACH"
+  },
+  {
+    "name": "FOREIGN"
+  },
+  {
+    "name": "FORM"
+  },
+  {
+    "name": "FORMAT"
+  },
+  {
+    "name": "FOUND"
+  },
+  {
+    "name": "FRACTION"
+  },
+  {
+    "name": "FREE"
+  },
+  {
+    "name": "FROM"
+  },
+  {
+    "name": "FULL"
+  },
+  {
+    "name": "FUNCTION",
+    "type": "keyword",
+    "description": "A FUNCTION definition defines a named procedure with a set of statements.",
+    "documentation": "https://4js.com/online_documentation/fjs-fgl-manual-html/#fgl-topics/c_fgl_Functions_syntax.html"
+  },
+  {
+    "name": "GET_FLDBUF",
+    "type": "operator"
+  },
+  {
+    "name": "GLOBALS"
+  },
+  {
+    "name": "GO"
+  },
+  {
+    "name": "GOTO"
+  },
+  {
+    "name": "GRANT"
+  },
+  {
+    "name": "GREEN",
+    "type": "color"
+  },
+  {
+    "name": "GROUP"
+  },
+  {
+    "name": "HANDLER"
+  },
+  {
+    "name": "HAVING"
+  },
+  {
+    "name": "HEADER"
+  },
+  {
+    "name": "HELP"
+  },
+  {
+    "name": "HIDE"
+  },
+  {
+    "name": "HOLD"
+  },
+  {
+    "name": "HOUR"
+  },
+  {
+    "name": "IDLE"
+  },
+  {
+    "name": "IF"
+  },
+  {
+    "name": "IIF"
+  },
+  {
+    "name": "IMAGE"
+  },
+  {
+    "name": "IMMEDIATE"
+  },
+  {
+    "name": "IMPORT"
+  },
+  {
+    "name": "IN"
+  },
+  {
+    "name": "INCREMENT"
+  },
+  {
+    "name": "INDEX"
+  },
+  {
+    "name": "INFIELD"
+  },
+  {
+    "name": "INITIALIZE"
+  },
+  {
+    "name": "INNER"
+  },
+  {
+    "name": "INOUT"
+  },
+  {
+    "name": "INPUT"
+  },
+  {
+    "name": "INSERT"
+  },
+  {
+    "name": "INSTANCEOF"
+  },
+  {
+    "name": "INT",
+    "type": "keyword"
+  },
+  {
+    "name": "INT8",
+    "type": "keyword"
+  },
+  {
+    "name": "INTEGER",
+    "type": "keyword"
+  },
+  {
+    "name": "INT_FLAG"
+  },
+  {
+    "name": "INTERFACE"
+  },
+  {
+    "name": "INTERRUPT"
+  },
+  {
+    "name": "INTERVAL"
+  },
+  {
+    "name": "INTO"
+  },
+  {
+    "name": "INVISIBLE"
+  },
+  {
+    "name": "IS"
+  },
+  {
+    "name": "ISOLATION"
+  },
+  {
+    "name": "JAVA"
+  },
+  {
+    "name": "JOIN"
+  },
+  {
+    "name": "KEEP"
+  },
+  {
+    "name": "KEY"
+  },
+  {
+    "name": "LABEL"
+  },
+  {
+    "name": "LAST"
+  },
+  {
+    "name": "LEFT"
+  },
+  {
+    "name": "LENGTH"
+  },
+  {
+    "name": "LET"
+  },
+  {
+    "name": "LIKE"
+  },
+  {
+    "name": "LIMIT"
+  },
+  {
+    "name": "LINE"
+  },
+  {
+    "name": "LINENO"
+  },
+  {
+    "name": "LINES"
+  },
+  {
+    "name": "LOAD"
+  },
+  {
+    "name": "LOCATE"
+  },
+  {
+    "name": "LOCK"
+  },
+  {
+    "name": "LOCKS"
+  },
+  {
+    "name": "LOG"
+  },
+  {
+    "name": "LSTR"
+  },
+  {
+    "name": "LVARCHAR",
+    "type": "keyword"
+  },
+  {
+    "name": "MAGENTA",
+    "type": "color",
+    "description": "The color MAGENTA used with the COLOR attribute.",
+    "documentation": "https://4js.com/online_documentation/fjs-fgl-manual-html/#fgl-topics/c_fgl_FSFAttributes_COLOR.html"
+  },
+  {
+    "name": "MAIN",
+    "type": "keyword",
+    "description": "The MAIN block is the starting point of the program.",
+    "documentation": "https://4js.com/online_documentation/fjs-fgl-manual-html/#fgl-topics/c_fgl_programs_MAIN.html"
+  },
+  {
+    "name": "MARGIN"
+  },
+  {
+    "name": "MATCHES"
+  },
+  {
+    "name": "MAX"
+  },
+  {
+    "name": "MAXCOUNT"
+  },
+  {
+    "name": "MAXVALUE"
+  },
+  {
+    "name": "MDY"
+  },
+  {
+    "name": "MEMORY"
+  },
+  {
+    "name": "MENU"
+  },
+  {
+    "name": "MESSAGE"
+  },
+  {
+    "name": "MIDDLE"
+  },
+  {
+    "name": "MIN"
+  },
+  {
+    "name": "MINUTE"
+  },
+  {
+    "name": "MINVALUE"
+  },
+  {
+    "name": "MOD"
+  },
+  {
+    "name": "MODE"
+  },
+  {
+    "name": "MODIFY"
+  },
+  {
+    "name": "MONEY"
+  },
+  {
+    "name": "MONTH"
+  },
+  {
+    "name": "NAME"
+  },
+  {
+    "name": "NATURAL"
+  },
+  {
+    "name": "NAVIGATOR"
+  },
+  {
+    "name": "NCHAR"
+  },
+  {
+    "name": "NEED"
+  },
+  {
+    "name": "NEXT"
+  },
+  {
+    "name": "NO"
+  },
+  {
+    "name": "NOCACHE"
+  },
+  {
+    "name": "NOCYCLE"
+  },
+  {
+    "name": "NOMAXVALUE"
+  },
+  {
+    "name": "NOMINVALUE"
+  },
+  {
+    "name": "NOORDER"
+  },
+  {
+    "name": "NORMAL"
+  },
+  {
+    "name": "NOT"
+  },
+  {
+    "name": "NOTFOUND"
+  },
+  {
+    "name": "NULL"
+  },
+  {
+    "name": "NUMERIC"
+  },
+  {
+    "name": "NVARCHAR"
+  },
+  {
+    "name": "NVL"
+  },
+  {
+    "name": "OF"
+  },
+  {
+    "name": "OFF"
+  },
+  {
+    "name": "ON"
+  },
+  {
+    "name": "OPEN"
+  },
+  {
+    "name": "OPTION"
+  },
+  {
+    "name": "OPTIONS"
+  },
+  {
+    "name": "OR"
+  },
+  {
+    "name": "ORD"
+  },
+  {
+    "name": "ORDER"
+  },
+  {
+    "name": "OTHERWISE"
+  },
+  {
+    "name": "OUT"
+  },
+  {
+    "name": "OUTER"
+  },
+  {
+    "name": "OUTPUT"
+  },
+  {
+    "name": "PACKAGE"
+  },
+  {
+    "name": "PAGE"
+  },
+  {
+    "name": "PAGENO"
+  },
+  {
+    "name": "PAUSE"
+  },
+  {
+    "name": "PERCENT"
+  },
+  {
+    "name": "PICTURE"
+  },
+  {
+    "name": "PIPE"
+  },
+  {
+    "name": "POPUP"
+  },
+  {
+    "name": "PRECISION"
+  },
+  {
+    "name": "PREPARE"
+  },
+  {
+    "name": "PREVIOUS"
+  },
+  {
+    "name": "PRIMARY"
+  },
+  {
+    "name": "PRINT"
+  },
+  {
+    "name": "PRINTER"
+  },
+  {
+    "name": "PRINTX"
+  },
+  {
+    "name": "PRIOR"
+  },
+  {
+    "name": "PRIVATE"
+  },
+  {
+    "name": "PRIVILEGES"
+  },
+  {
+    "name": "PROCEDURE"
+  },
+  {
+    "name": "PROGRAM"
+  },
+  {
+    "name": "PROMPT"
+  },
+  {
+    "name": "PUBLIC"
+  },
+  {
+    "name": "PUT"
+  },
+  {
+    "name": "QUIT"
+  },
+  {
+    "name": "RAISE"
+  },
+  {
+    "name": "READ"
+  },
+  {
+    "name": "REAL",
+    "type": "keyword"
+  },
+  {
+    "name": "RECORD",
+    "type": "keyword"
+  },
+  {
+    "name": "RECOVER"
+  },
+  {
+    "name": "RED",
+    "type": "color"
+  },
+  {
+    "name": "REFERENCES"
+  },
+  {
+    "name": "RELATIVE"
+  },
+  {
+    "name": "RELEASE"
+  },
+  {
+    "name": "RENAME"
+  },
+  {
+    "name": "REOPTIMIZATION"
+  },
+  {
+    "name": "REPEATABLE"
+  },
+  {
+    "name": "REPORT"
+  },
+  {
+    "name": "RESOURCE"
+  },
+  {
+    "name": "RESTART"
+  },
+  {
+    "name": "RETAIN"
+  },
+  {
+    "name": "RETURN"
+  },
+  {
+    "name": "RETURNING"
+  },
+  {
+    "name": "RETURNS"
+  },
+  {
+    "name": "REVERSE"
+  },
+  {
+    "name": "REVOKE"
+  },
+  {
+    "name": "RIGHT"
+  },
+  {
+    "name": "ROLLBACK"
+  },
+  {
+    "name": "ROLLFORWARD"
+  },
+  {
+    "name": "ROW"
+  },
+  {
+    "name": "ROWBOUND"
+  },
+  {
+    "name": "ROWS"
+  },
+  {
+    "name": "RUN"
+  },
+  {
+    "name": "SAVEPOINT"
+  },
+  {
+    "name": "SCHEMA",
+    "type": "keyword",
+    "description": "Defines the database schema files to be used for compilation.",
+    "documentation": "https://4js.com/online_documentation/fjs-fgl-manual-html/#fgl-topics/c_fgl_DatabaseSchema_SCHEMA.html"
+  },
+  {
+    "name": "SCREEN"
+  },
+  {
+    "name": "SCROLL"
+  },
+  {
+    "name": "SECOND"
+  },
+  {
+    "name": "SELECT"
+  },
+  {
+    "name": "SELECTION"
+  },
+  {
+    "name": "SEQUENCE"
+  },
+  {
+    "name": "SERIAL"
+  },
+  {
+    "name": "SERIAL8"
+  },
+  {
+    "name": "SESSION"
+  },
+  {
+    "name": "SET"
+  },
+  {
+    "name": "SFMT"
+  },
+  {
+    "name": "SHARE"
+  },
+  {
+    "name": "SHIFT"
+  },
+  {
+    "name": "SHORT"
+  },
+  {
+    "name": "SHOW"
+  },
+  {
+    "name": "SIGNAL"
+  },
+  {
+    "name": "SITENAME"
+  },
+  {
+    "name": "SIZE"
+  },
+  {
+    "name": "SKIP"
+  },
+  {
+    "name": "SLEEP"
+  },
+  {
+    "name": "SMALLFLOAT"
+  },
+  {
+    "name": "SMALLINT"
+  },
+  {
+    "name": "SOME"
+  },
+  {
+    "name": "SORT"
+  },
+  {
+    "name": "SPACE"
+  },
+  {
+    "name": "SPACES"
+  },
+  {
+    "name": "SQL"
+  },
+  {
+    "name": "SQLCA"
+  },
+  {
+    "name": "SQLERRMESSAGE",
+    "type": "variable",
+    "description": "The SQLERRMESSAGE variable holds the error message corresponding to the last SQL error.",
+    "documentation": "https://4js.com/online_documentation/fjs-fgl-manual-html/#fgl-topics/c_fgl_operators_SQLERRMESSAGE.html"
+  },
+  {
+    "name": "SQLERROR"
+  },
+  {
+    "name": "SQLSTATE",
+    "type": "variable",
+    "description": "The SQLSTATE variable returns the code corresponding to the last SQL error.",
+    "documentation": "https://4js.com/online_documentation/fjs-fgl-manual-html/#fgl-topics/c_fgl_operators_SQLSTATE.html"
+  },
+  {
+    "name": "STABILITY"
+  },
+  {
+    "name": "START"
+  },
+  {
+    "name": "STATISTICS"
+  },
+  {
+    "name": "STATUS"
+  },
+  {
+    "name": "STEP"
+  },
+  {
+    "name": "STOP"
+  },
+  {
+    "name": "STRING"
+  },
+  {
+    "name": "STYLE"
+  },
+  {
+    "name": "SUBDIALOG"
+  },
+  {
+    "name": "SUM"
+  },
+  {
+    "name": "SYNONYM"
+  },
+  {
+    "name": "TABLE"
+  },
+  {
+    "name": "TEMP"
+  },
+  {
+    "name": "TERMINATE"
+  },
+  {
+    "name": "TEXT"
+  },
+  {
+    "name": "THEN"
+  },
+  {
+    "name": "THROUGH"
+  },
+  {
+    "name": "THRU"
+  },
+  {
+    "name": "TIME"
+  },
+  {
+    "name": "TIMER"
+  },
+  {
+    "name": "TINYINT"
+  },
+  {
+    "name": "TO"
+  },
+  {
+    "name": "TODAY",
+    "type": "operator"
+  },
+  {
+    "name": "TOP"
+  },
+  {
+    "name": "TRAILER"
+  },
+  {
+    "name": "TRANSACTION"
+  },
+  {
+    "name": "TRUE",
+    "type": "constant"
+  },
+  {
+    "name": "TRUNCATE"
+  },
+  {
+    "name": "TRUSTED"
+  },
+  {
+    "name": "TRY"
+  },
+  {
+    "name": "TYPE"
+  },
+  {
+    "name": "UNBUFFERED"
+  },
+  {
+    "name": "UNCONSTRAINED"
+  },
+  {
+    "name": "UNDERLINE"
+  },
+  {
+    "name": "UNION"
+  },
+  {
+    "name": "UNIQUE"
+  },
+  {
+    "name": "UNITS"
+  },
+  {
+    "name": "UNLOAD"
+  },
+  {
+    "name": "UNLOCK"
+  },
+  {
+    "name": "UP"
+  },
+  {
+    "name": "UPDATE"
+  },
+  {
+    "name": "USER"
+  },
+  {
+    "name": "USING"
+  },
+  {
+    "name": "VALIDATE"
+  },
+  {
+    "name": "VAR"
+  },
+  {
+    "name": "VALUES"
+  },
+  {
+    "name": "VARCHAR",
+    "type": "keyword"
+  },
+  {
+    "name": "VIEW"
+  },
+  {
+    "name": "WAIT"
+  },
+  {
+    "name": "WAITING"
+  },
+  {
+    "name": "WARNING"
+  },
+  {
+    "name": "WEEKDAY"
+  },
+  {
+    "name": "WHEN"
+  },
+  {
+    "name": "WHENEVER"
+  },
+  {
+    "name": "WHERE"
+  },
+  {
+    "name": "WHILE"
+  },
+  {
+    "name": "WHITE",
+    "type": "color"
+  },
+  {
+    "name": "WINDOW"
+  },
+  {
+    "name": "WITH"
+  },
+  {
+    "name": "WITHOUT"
+  },
+  {
+    "name": "WORDWRAP"
+  },
+  {
+    "name": "WORK"
+  },
+  {
+    "name": "WRAP"
+  },
+  {
+    "name": "XML"
+  },
+  {
+    "name": "YEAR"
+  },
+  {
+    "name": "YELLOW",
+    "type": "color"
+  },
+  {
+    "name": "YES"
+  }
+]

--- a/extension/Resources/GeneroPackageSchema.json
+++ b/extension/Resources/GeneroPackageSchema.json
@@ -1,0 +1,199 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "title": "Package Schema",
+  "description": "JSON Schema for Genero Packages",
+  "type": "object",
+  "allOf": [
+    {
+      "properties": {
+        "type": {
+          "description": "Type of package",
+          "type": "string",
+          "enum": [
+            "built-in",
+            "external"
+          ]
+        },
+        "classes": {
+          "description": "List of classes available in the package",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/class"
+          }
+        }
+      }
+    },
+    {
+      "$ref": "#/definitions/basicInfo"
+    }
+  ],
+  "definitions": {
+    "class": {
+      "description": "Class of a package",
+      "type": "object",
+      "allOf": [
+        {
+          "properties": {
+            "classMethods": {
+              "description": "Methods available as a class",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/classMethod"
+              }
+            },
+            "objectMethods": {
+              "description": "Methods available as an object",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/objectMethod"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/basicInfo"
+        }
+      ],
+      "required": [
+        "name"
+      ]
+    },
+    "classMethod": {
+      "description": "Method available as a class",
+      "type": "object",
+      "$ref": "#/definitions/method"
+    },
+    "objectMethod": {
+      "description": "Method available as an object",
+      "type": "object",
+      "$ref": "#/definitions/method"
+    },
+    "parameter": {
+      "description": "Method parameter",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Parameter name",
+          "type": "string"
+        },
+        "type": {
+          "description": "Parameter data type",
+          "type": "string"
+        },
+        "description": {
+          "description": "Description of the parameter",
+          "type": "string"
+        },
+        "recordMembers": {
+          "type": "array",
+          "description": "Members of the record parameter",
+          "items": {
+            "$ref": "#/definitions/member"
+          }
+        }
+      },
+      "required": [
+        "name",
+        "type"
+      ]
+    },
+    "return": {
+      "description": "Method return",
+      "type": "object",
+      "properties": {
+        "type": {
+          "description": "Return data type",
+          "type": "string"
+        },
+        "description": {
+          "description": "Description of the return",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "method": {
+      "description": "Method of a package class",
+      "type": "object",
+      "allOf": [
+        {
+          "properties": {
+            "parameters": {
+              "description": "Parameters of the method",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/parameter"
+              }
+            },
+            "returns": {
+              "description": "Returns of the method",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/return"
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/basicInfo"
+        }
+      ],
+      "required": [
+        "name"
+      ]
+    },
+    "basicInfo": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Name of the package/class/method",
+          "type": "string"
+        },
+        "description": {
+          "description": "Description of the package/class/method",
+          "type": "string"
+        },
+        "documentation": {
+          "description": "HTML link to the documentation for the package/class/method",
+          "type": "string",
+          "pattern": "(?i)\\.html$"
+        },
+        "minimumLanguageVersion": {
+          "description": "Minimum Genero version the package/class/method is available in",
+          "type": "string",
+          "default": "none"
+        },
+        "maximumLanguageVersion": {
+          "description": "Maximum Genero version the package/class/method is available in",
+          "type": "string",
+          "default": "latest"
+        }
+      }
+    },
+    "member": {
+      "type": "object",
+      "description": "Record member",
+      "properties": {
+        "name": {
+          "description": "Member name",
+          "type": "string"
+        },
+        "type": {
+          "description": "Member data type",
+          "type": "string"
+        },
+        "description": {
+          "description": "Description of the member",
+          "type": "string"
+        }
+      }
+    }
+  },
+  "required": [
+    "name",
+    "type",
+    "classes"
+  ]
+}

--- a/extension/Resources/PERKeywords.json
+++ b/extension/Resources/PERKeywords.json
@@ -1,0 +1,1076 @@
+{
+  "keywords": [
+    {
+      "name": "ACCELERATOR",
+      "type": "keyword"
+    },
+    {
+      "name": "ACCELERATOR2",
+      "type": "keyword"
+    },
+    {
+      "name": "ACCELERATOR3",
+      "type": "keyword"
+    },
+    {
+      "name": "ACCELERATOR4",
+      "type": "keyword"
+    },
+    {
+      "name": "ACTION",
+      "type": "keyword"
+    },
+    {
+      "name": "ACTIONS",
+      "type": "keyword"
+    },
+    {
+      "name": "ACTIONIMAGE",
+      "type": "keyword"
+    },
+    {
+      "name": "ACTIONTEXT",
+      "type": "keyword"
+    },
+    {
+      "name": "AGGREGATE",
+      "type": "keyword"
+    },
+    {
+      "name": "AGGREGATETEXT",
+      "type": "keyword"
+    },
+    {
+      "name": "AGGREGATETYPE",
+      "type": "keyword"
+    },
+    {
+      "name": "ALT",
+      "type": "keyword"
+    },
+    {
+      "name": "AND",
+      "type": "keyword"
+    },
+    {
+      "name": "ATTRIBUTES",
+      "type": "keyword"
+    },
+    {
+      "name": "AUTO",
+      "type": "keyword"
+    },
+    {
+      "name": "AUTOCOMMANDS",
+      "type": "keyword"
+    },
+    {
+      "name": "AUTOHIDE",
+      "type": "keyword"
+    },
+    {
+      "name": "AUTOITEMS",
+      "type": "keyword"
+    },
+    {
+      "name": "AUTONEXT",
+      "type": "keyword"
+    },
+    {
+      "name": "AUTOSCALE",
+      "type": "keyword"
+    },
+    {
+      "name": "AVG",
+      "type": "keyword"
+    },
+    {
+      "name": "BETWEEN",
+      "type": "keyword"
+    },
+    {
+      "name": "BIGINT",
+      "type": "keyword"
+    },
+    {
+      "name": "BLACK",
+      "type": "keyword"
+    },
+    {
+      "name": "BLINK",
+      "type": "keyword"
+    },
+    {
+      "name": "BLUE",
+      "type": "keyword"
+    },
+    {
+      "name": "BOOLEAN",
+      "type": "keyword"
+    },
+    {
+      "name": "BOTH",
+      "type": "keyword"
+    },
+    {
+      "name": "BUTTON",
+      "type": "keyword"
+    },
+    {
+      "name": "BUTTONEDIT",
+      "type": "keyword"
+    },
+    {
+      "name": "BUTTONTEXTHIDDEN",
+      "type": "keyword"
+    },
+    {
+      "name": "BY",
+      "type": "keyword"
+    },
+    {
+      "name": "BYTE",
+      "type": "keyword"
+    },
+    {
+      "name": "CANVAS",
+      "type": "keyword"
+    },
+    {
+      "name": "CENTER",
+      "type": "keyword"
+    },
+    {
+      "name": "CENTURY",
+      "type": "keyword"
+    },
+    {
+      "name": "CHAR",
+      "type": "keyword"
+    },
+    {
+      "name": "CHARACTER",
+      "type": "keyword"
+    },
+    {
+      "name": "CHARACTERS",
+      "type": "keyword"
+    },
+    {
+      "name": "CHECKBOX",
+      "type": "keyword"
+    },
+    {
+      "name": "CLASS",
+      "type": "keyword"
+    },
+    {
+      "name": "COLOR",
+      "type": "keyword"
+    },
+    {
+      "name": "COLUMNS",
+      "type": "keyword"
+    },
+    {
+      "name": "COMBOBOX",
+      "type": "keyword"
+    },
+    {
+      "name": "COMMAND",
+      "type": "keyword"
+    },
+    {
+      "name": "COMMENT",
+      "type": "keyword"
+    },
+    {
+      "name": "COMMENTS",
+      "type": "keyword"
+    },
+    {
+      "name": "COMPACT",
+      "type": "keyword"
+    },
+    {
+      "name": "COMPLETER",
+      "type": "keyword"
+    },
+    {
+      "name": "COMPONENTTYPE",
+      "type": "keyword"
+    },
+    {
+      "name": "COMPRESS",
+      "type": "keyword"
+    },
+    {
+      "name": "CONFIG",
+      "type": "keyword"
+    },
+    {
+      "name": "CONTENT",
+      "type": "keyword"
+    },
+    {
+      "name": "CONTEXTMENU",
+      "type": "keyword"
+    },
+    {
+      "name": "CONTROL",
+      "type": "keyword"
+    },
+    {
+      "name": "COUNT",
+      "type": "keyword"
+    },
+    {
+      "name": "CURRENT",
+      "type": "keyword"
+    },
+    {
+      "name": "CYAN",
+      "type": "keyword"
+    },
+    {
+      "name": "DATABASE",
+      "type": "keyword"
+    },
+    {
+      "name": "DATE",
+      "type": "keyword"
+    },
+    {
+      "name": "DATEEDIT",
+      "type": "keyword"
+    },
+    {
+      "name": "DATETIME",
+      "type": "keyword"
+    },
+    {
+      "name": "DATETIMEEDIT",
+      "type": "keyword"
+    },
+    {
+      "name": "DAY",
+      "type": "keyword"
+    },
+    {
+      "name": "DEC",
+      "type": "keyword"
+    },
+    {
+      "name": "DECIMAL",
+      "type": "keyword"
+    },
+    {
+      "name": "DEFAULT",
+      "type": "keyword"
+    },
+    {
+      "name": "DEFAULTS",
+      "type": "keyword"
+    },
+    {
+      "name": "DEFAULTVIEW",
+      "type": "keyword"
+    },
+    {
+      "name": "DELIMITERS",
+      "type": "keyword"
+    },
+    {
+      "name": "DISCLOSUREINDICATOR",
+      "type": "keyword"
+    },
+    {
+      "name": "DISPLAY",
+      "type": "keyword"
+    },
+    {
+      "name": "DISPLAYONLY",
+      "type": "keyword"
+    },
+    {
+      "name": "DOUBLE",
+      "type": "keyword"
+    },
+    {
+      "name": "DOUBLECLICK",
+      "type": "keyword"
+    },
+    {
+      "name": "DOWNSHIFT",
+      "type": "keyword"
+    },
+    {
+      "name": "DYNAMIC",
+      "type": "keyword"
+    },
+    {
+      "name": "EDIT",
+      "type": "keyword"
+    },
+    {
+      "name": "EMAIL",
+      "type": "keyword"
+    },
+    {
+      "name": "END",
+      "type": "keyword"
+    },
+    {
+      "name": "EXPANDEDCOLUMN",
+      "type": "keyword"
+    },
+    {
+      "name": "FALSE",
+      "type": "keyword"
+    },
+    {
+      "name": "FIELD",
+      "type": "keyword"
+    },
+    {
+      "name": "FIXED",
+      "type": "keyword"
+    },
+    {
+      "name": "FLIPPED",
+      "type": "keyword"
+    },
+    {
+      "name": "FLOAT",
+      "type": "keyword"
+    },
+    {
+      "name": "FOLDER",
+      "type": "keyword"
+    },
+    {
+      "name": "FONTPITCH",
+      "type": "keyword"
+    },
+    {
+      "name": "FORM",
+      "type": "keyword"
+    },
+    {
+      "name": "FORMAT",
+      "type": "keyword"
+    },
+    {
+      "name": "FORMONLY",
+      "type": "keyword"
+    },
+    {
+      "name": "FRACTION",
+      "type": "keyword"
+    },
+    {
+      "name": "GREEN",
+      "type": "keyword"
+    },
+    {
+      "name": "GRID",
+      "type": "keyword"
+    },
+    {
+      "name": "GRIDCHILDRENINPARENT",
+      "type": "keyword"
+    },
+    {
+      "name": "GROUP",
+      "type": "keyword"
+    },
+    {
+      "name": "HBOX",
+      "type": "keyword"
+    },
+    {
+      "name": "HEIGHT",
+      "type": "keyword"
+    },
+    {
+      "name": "HIDDEN",
+      "type": "keyword"
+    },
+    {
+      "name": "HORIZONTAL",
+      "type": "keyword"
+    },
+    {
+      "name": "HOUR",
+      "type": "keyword"
+    },
+    {
+      "name": "IDCOLUMN",
+      "type": "keyword"
+    },
+    {
+      "name": "IMAGE",
+      "type": "keyword"
+    },
+    {
+      "name": "IMAGECOLLAPSED",
+      "type": "keyword"
+    },
+    {
+      "name": "IMAGECOLUMN",
+      "type": "keyword"
+    },
+    {
+      "name": "IMAGEEXPANDED",
+      "type": "keyword"
+    },
+    {
+      "name": "IMAGELEAF",
+      "type": "keyword"
+    },
+    {
+      "name": "INCLUDE",
+      "type": "keyword"
+    },
+    {
+      "name": "INITIAL",
+      "type": "keyword"
+    },
+    {
+      "name": "INITIALIZER",
+      "type": "keyword"
+    },
+    {
+      "name": "INITIALPAGESIZE",
+      "type": "keyword"
+    },
+    {
+      "name": "INPUT",
+      "type": "keyword"
+    },
+    {
+      "name": "INSTRUCTIONS",
+      "type": "keyword"
+    },
+    {
+      "name": "INT",
+      "type": "keyword"
+    },
+    {
+      "name": "INTEGER",
+      "type": "keyword"
+    },
+    {
+      "name": "INTERVAL",
+      "type": "keyword"
+    },
+    {
+      "name": "INVISIBLE",
+      "type": "keyword"
+    },
+    {
+      "name": "IS",
+      "type": "keyword"
+    },
+    {
+      "name": "ISNODECOLUMN",
+      "type": "keyword"
+    },
+    {
+      "name": "ITEM",
+      "type": "keyword"
+    },
+    {
+      "name": "ITEMS",
+      "type": "keyword"
+    },
+    {
+      "name": "JUSTIFY",
+      "type": "keyword"
+    },
+    {
+      "name": "KEY",
+      "type": "keyword"
+    },
+    {
+      "name": "KEYBOARDHINT",
+      "type": "keyword"
+    },
+    {
+      "name": "KEYS",
+      "type": "keyword"
+    },
+    {
+      "name": "LABEL",
+      "type": "keyword"
+    },
+    {
+      "name": "LARGE",
+      "type": "keyword"
+    },
+    {
+      "name": "LAYOUT",
+      "type": "keyword"
+    },
+    {
+      "name": "LEFT",
+      "type": "keyword"
+    },
+    {
+      "name": "LIKE",
+      "type": "keyword"
+    },
+    {
+      "name": "LINES",
+      "type": "keyword"
+    },
+    {
+      "name": "MAGENTA",
+      "type": "keyword"
+    },
+    {
+      "name": "MATCHES",
+      "type": "keyword"
+    },
+    {
+      "name": "MAX",
+      "type": "keyword"
+    },
+    {
+      "name": "MEDIUM",
+      "type": "keyword"
+    },
+    {
+      "name": "MIN",
+      "type": "keyword"
+    },
+    {
+      "name": "MINHEIGHT",
+      "type": "keyword"
+    },
+    {
+      "name": "MINUTE",
+      "type": "keyword"
+    },
+    {
+      "name": "MINWIDTH",
+      "type": "keyword"
+    },
+    {
+      "name": "MONEY",
+      "type": "keyword"
+    },
+    {
+      "name": "MONTH",
+      "type": "keyword"
+    },
+    {
+      "name": "NO",
+      "type": "keyword"
+    },
+    {
+      "name": "NOENTRY",
+      "type": "keyword"
+    },
+    {
+      "name": "NONCOMPRESS",
+      "type": "keyword"
+    },
+    {
+      "name": "NONE",
+      "type": "keyword"
+    },
+    {
+      "name": "NORMAL",
+      "type": "keyword"
+    },
+    {
+      "name": "NOSWIPE",
+      "type": "keyword"
+    },
+    {
+      "name": "NOT",
+      "type": "keyword"
+    },
+    {
+      "name": "NOTEDITABLE",
+      "type": "keyword"
+    },
+    {
+      "name": "NOUPDATE",
+      "type": "keyword"
+    },
+    {
+      "name": "NULL",
+      "type": "keyword"
+    },
+    {
+      "name": "NUMBER",
+      "type": "keyword"
+    },
+    {
+      "name": "NUMERIC",
+      "type": "keyword"
+    },
+    {
+      "name": "OPTIONS",
+      "type": "keyword"
+    },
+    {
+      "name": "OR",
+      "type": "keyword"
+    },
+    {
+      "name": "ORIENTATION",
+      "type": "keyword"
+    },
+    {
+      "name": "PACKED",
+      "type": "keyword"
+    },
+    {
+      "name": "PAGE",
+      "type": "keyword"
+    },
+    {
+      "name": "PARENTIDCOLUMN",
+      "type": "keyword"
+    },
+    {
+      "name": "PHANTOM",
+      "type": "keyword"
+    },
+    {
+      "name": "PHONE",
+      "type": "keyword"
+    },
+    {
+      "name": "PICTURE",
+      "type": "keyword"
+    },
+    {
+      "name": "PIXELHEIGHT",
+      "type": "keyword"
+    },
+    {
+      "name": "PIXELS",
+      "type": "keyword"
+    },
+    {
+      "name": "PIXELWIDTH",
+      "type": "keyword"
+    },
+    {
+      "name": "PLACEHOLDER",
+      "type": "keyword"
+    },
+    {
+      "name": "POINTS",
+      "type": "keyword"
+    },
+    {
+      "name": "PRECISION",
+      "type": "keyword"
+    },
+    {
+      "name": "PROGRAM",
+      "type": "keyword"
+    },
+    {
+      "name": "PROGRAMS",
+      "type": "keyword"
+    },
+    {
+      "name": "PROGRESSBAR",
+      "type": "keyword"
+    },
+    {
+      "name": "PROPERTIES",
+      "type": "keyword"
+    },
+    {
+      "name": "QUERYCLEAR",
+      "type": "keyword"
+    },
+    {
+      "name": "QUERYEDITABLE",
+      "type": "keyword"
+    },
+    {
+      "name": "RADIOGROUP",
+      "type": "keyword"
+    },
+    {
+      "name": "REAL",
+      "type": "keyword"
+    },
+    {
+      "name": "RECORD",
+      "type": "keyword"
+    },
+    {
+      "name": "RED",
+      "type": "keyword"
+    },
+    {
+      "name": "REQUIRED",
+      "type": "keyword"
+    },
+    {
+      "name": "REVERSE",
+      "type": "keyword"
+    },
+    {
+      "name": "RIGHT",
+      "type": "keyword"
+    },
+    {
+      "name": "SAMPLE",
+      "type": "keyword"
+    },
+    {
+      "name": "SCHEMA",
+      "type": "keyword"
+    },
+    {
+      "name": "SCREEN",
+      "type": "keyword"
+    },
+    {
+      "name": "SCROLL",
+      "type": "keyword"
+    },
+    {
+      "name": "SCROLLBARS",
+      "type": "keyword"
+    },
+    {
+      "name": "SCROLLGRID",
+      "type": "keyword"
+    },
+    {
+      "name": "SEARCH",
+      "type": "keyword"
+    },
+    {
+      "name": "SECOND",
+      "type": "keyword"
+    },
+    {
+      "name": "SEPARATOR",
+      "type": "keyword"
+    },
+    {
+      "name": "SHIFT",
+      "type": "keyword"
+    },
+    {
+      "name": "SIZE",
+      "type": "keyword"
+    },
+    {
+      "name": "SIZEPOLICY",
+      "type": "keyword"
+    },
+    {
+      "name": "SLIDER",
+      "type": "keyword"
+    },
+    {
+      "name": "SMALL",
+      "type": "keyword"
+    },
+    {
+      "name": "SMALLFLOAT",
+      "type": "keyword"
+    },
+    {
+      "name": "SMALLINT",
+      "type": "keyword"
+    },
+    {
+      "name": "SPACING",
+      "type": "keyword"
+    },
+    {
+      "name": "SPINEDIT",
+      "type": "keyword"
+    },
+    {
+      "name": "SPLIT",
+      "type": "keyword"
+    },
+    {
+      "name": "SPLITTER",
+      "type": "keyword"
+    },
+    {
+      "name": "STEP",
+      "type": "keyword"
+    },
+    {
+      "name": "STRETCH",
+      "type": "keyword"
+    },
+    {
+      "name": "STRETCHCOLUMNS",
+      "type": "keyword"
+    },
+    {
+      "name": "STRETCHMAX",
+      "type": "keyword"
+    },
+    {
+      "name": "STRETCHMIN",
+      "type": "keyword"
+    },
+    {
+      "name": "STYLE",
+      "type": "keyword"
+    },
+    {
+      "name": "SUM",
+      "type": "keyword"
+    },
+    {
+      "name": "TABINDEX",
+      "type": "keyword"
+    },
+    {
+      "name": "TABLE",
+      "type": "keyword"
+    },
+    {
+      "name": "TABLES",
+      "type": "keyword"
+    },
+    {
+      "name": "TAG",
+      "type": "keyword"
+    },
+    {
+      "name": "TEXT",
+      "type": "keyword"
+    },
+    {
+      "name": "TEXTEDIT",
+      "type": "keyword"
+    },
+    {
+      "name": "THROUGH",
+      "type": "keyword"
+    },
+    {
+      "name": "THRU",
+      "type": "keyword"
+    },
+    {
+      "name": "TIMEEDIT",
+      "type": "keyword"
+    },
+    {
+      "name": "TIMESTAMP",
+      "type": "keyword"
+    },
+    {
+      "name": "TITLE",
+      "type": "keyword"
+    },
+    {
+      "name": "TO",
+      "type": "keyword"
+    },
+    {
+      "name": "TODAY",
+      "type": "keyword"
+    },
+    {
+      "name": "TOOLBAR",
+      "type": "keyword"
+    },
+    {
+      "name": "TOPMENU",
+      "type": "keyword"
+    },
+    {
+      "name": "TREE",
+      "type": "keyword"
+    },
+    {
+      "name": "TRUE",
+      "type": "keyword"
+    },
+    {
+      "name": "TYPE",
+      "type": "keyword"
+    },
+    {
+      "name": "UNDERLINE",
+      "type": "keyword"
+    },
+    {
+      "name": "UNHIDABLE",
+      "type": "keyword"
+    },
+    {
+      "name": "UNHIDABLECOLUMNS",
+      "type": "keyword"
+    },
+    {
+      "name": "UNMOVABLE",
+      "type": "keyword"
+    },
+    {
+      "name": "UNMOVABLECOLUMNS",
+      "type": "keyword"
+    },
+    {
+      "name": "UNSIZABLE",
+      "type": "keyword"
+    },
+    {
+      "name": "UNSIZABLECOLUMNS",
+      "type": "keyword"
+    },
+    {
+      "name": "UNSORTABLE",
+      "type": "keyword"
+    },
+    {
+      "name": "UNSORTABLECOLUMNS",
+      "type": "keyword"
+    },
+    {
+      "name": "UPSHIFT",
+      "type": "keyword"
+    },
+    {
+      "name": "URL",
+      "type": "keyword"
+    },
+    {
+      "name": "USER",
+      "type": "keyword"
+    },
+    {
+      "name": "VALIDATE",
+      "type": "keyword"
+    },
+    {
+      "name": "VALUECHECKED",
+      "type": "keyword"
+    },
+    {
+      "name": "VALUEMAX",
+      "type": "keyword"
+    },
+    {
+      "name": "VALUEMIN",
+      "type": "keyword"
+    },
+    {
+      "name": "VALUEUNCHECKED",
+      "type": "keyword"
+    },
+    {
+      "name": "VARCHAR",
+      "type": "keyword"
+    },
+    {
+      "name": "VARIABLE",
+      "type": "keyword"
+    },
+    {
+      "name": "VBOX",
+      "type": "keyword"
+    },
+    {
+      "name": "VERIFY",
+      "type": "keyword"
+    },
+    {
+      "name": "VERSION",
+      "type": "keyword"
+    },
+    {
+      "name": "VERTICAL",
+      "type": "keyword"
+    },
+    {
+      "name": "WANTFIXEDPAGESIZE",
+      "type": "keyword"
+    },
+    {
+      "name": "WANTNORETURNS",
+      "type": "keyword"
+    },
+    {
+      "name": "WANTTABS",
+      "type": "keyword"
+    },
+    {
+      "name": "WEBCOMPONENT",
+      "type": "keyword"
+    },
+    {
+      "name": "WHERE",
+      "type": "keyword"
+    },
+    {
+      "name": "WHITE",
+      "type": "keyword"
+    },
+    {
+      "name": "WIDGET",
+      "type": "keyword"
+    },
+    {
+      "name": "WIDTH",
+      "type": "keyword"
+    },
+    {
+      "name": "WINDOWS",
+      "type": "keyword"
+    },
+    {
+      "name": "WINDOWSTYLE",
+      "type": "keyword"
+    },
+    {
+      "name": "WITHOUT",
+      "type": "keyword"
+    },
+    {
+      "name": "WORDWRAP",
+      "type": "keyword"
+    },
+    {
+      "name": "WIP",
+      "type": "keyword"
+    },
+    {
+      "name": "X",
+      "type": "keyword"
+    },
+    {
+      "name": "Y",
+      "type": "keyword"
+    },
+    {
+      "name": "YEAR",
+      "type": "keyword"
+    },
+    {
+      "name": "YELLOW",
+      "type": "keyword"
+    },
+    {
+      "name": "YES",
+      "type": "keyword"
+    },
+    {
+      "name": "ZEROFILL",
+      "type": "keyword"
+    }
+  ]
+}

--- a/extension/Resources/built-in_base.4GLPackage.json
+++ b/extension/Resources/built-in_base.4GLPackage.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "./GeneroPackageSchema.json",
+  "name": "base",
+  "type": "built-in",
+  "classes": [
+    {
+      "name": "Application"
+    },
+    {
+      "name": "Channel"
+    },
+    {
+      "name": "SqlHandler"
+    },
+    {
+      "name": "StringBuffer"
+    },
+    {
+      "name": "StringTokenizer"
+    },
+    {
+      "name": "TypeInfo"
+    },
+    {
+      "name": "MessageServer"
+    }
+  ]
+}

--- a/extension/Resources/built-in_dataTypes.4GLPackage.json
+++ b/extension/Resources/built-in_dataTypes.4GLPackage.json
@@ -1,0 +1,256 @@
+{
+  "$schema": "./GeneroPackageSchema.json",
+  "name": "dataTypes",
+  "type": "built-in",
+  "description": "Built-in classes for BDL data types",
+  "documentation": "c_fgl_Class_datatypes.html",
+  "minimumLanguageVersion": "none",
+  "maximumLanguageVersion": "latest",
+  "classes": [
+    {
+      "name": "BYTE",
+      "description": "The BYTE primitive data type provides a set of utility methods to manipulate BYTE data.",
+      "documentation": "c_fgl_datatypes_BYTE_as_class.html",
+      "minimumLanguageVersion": "none",
+      "maximumLanguageVersion": "latest",
+      "objectMethods": [
+        {
+          "name": "readFile",
+          "description": "Reads a file into a BYTE locator",
+          "documentation": "c_fgl_datatypes_BYTE_readFile.html",
+          "minimumLanguageVersion": "none",
+          "maximumLanguageVersion": "latest",
+          "parameters": [
+            {
+              "name": "path",
+              "type": "STRING",
+              "description": "The path to the file to be loaded."
+            }
+          ]
+        },
+        {
+          "name": "writeFile",
+          "description": "Writes the content of a BYTE to a file.",
+          "documentation": "c_fgl_datatypes_BYTE_writeFile.html",
+          "minimumLanguageVersion": "none",
+          "maximumLanguageVersion": "latest",
+          "parameters": [
+            {
+              "name": "path",
+              "type": "STRING",
+              "description": "The path to the file to be written to."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "STRING",
+      "description": "The STRING primitive data type provides a set of utility methods to manipulate character strings.",
+      "documentation": "c_fgl_datatypes_STRING_as_class.html",
+      "minimumLanguageVersion": "none",
+      "maximumLanguageVersion": "latest",
+      "objectMethods": [
+        {
+          "name": "append",
+          "description": "Concatenates a string",
+          "documentation": "c_fgl_datatypes_STRING_append.html",
+          "minimumLanguageVersion": "none",
+          "maximumLanguageVersion": "latest",
+          "parameters": [
+            {
+              "name": "str",
+              "type": "STRING",
+              "description": "The string to be concatenated."
+            }
+          ],
+          "returns": [
+            {
+              "type": "STRING",
+              "description": "Concatenated string."
+            }
+          ]
+        },
+        {
+          "name": "equals",
+          "description": "Compares a string to the content of a string variable.",
+          "documentation": "c_fgl_datatypes_STRING_equals.html",
+          "minimumLanguageVersion": "none",
+          "maximumLanguageVersion": "latest",
+          "parameters": [
+            {
+              "name": "str",
+              "type": "STRING",
+              "description": "The string to compare with."
+            }
+          ],
+          "returns": [
+            {
+              "type": "BOOLEAN",
+              "description": ""
+            }
+          ]
+        },
+        {
+          "name": "equalsIgnoreCase",
+          "description": "Makes a case-insensitive string comparison.",
+          "documentation": "c_fgl_datatypes_STRING_equalsIgnoreCase.html",
+          "minimumLanguageVersion": "none",
+          "maximumLanguageVersion": "latest",
+          "parameters": [
+            {
+              "name": "str",
+              "type": "STRING",
+              "description": "The string to compare with."
+            }
+          ],
+          "returns": [
+            {
+              "type": "BOOLEAN",
+              "description": ""
+            }
+          ]
+        },
+        {
+          "name": "getCharAt",
+          "description": "Returns the character at the specified position.",
+          "documentation": "c_fgl_datatypes_STRING_getCharAt.html",
+          "minimumLanguageVersion": "none",
+          "maximumLanguageVersion": "latest",
+          "parameters": [
+            {
+              "name": "index",
+              "type": "INTEGER",
+              "description": "The position of the character int the string."
+            }
+          ],
+          "returns": [
+            {
+              "type": "CHAR(1)",
+              "description": "The character at the specified position from the STRING variable."
+            }
+          ]
+        },
+        {
+          "name": "getIndexOf",
+          "description": "Returns the position of a substring.",
+          "documentation": "c_fgl_datatypes_STRING_getIndexOf.html",
+          "minimumLanguageVersion": "none",
+          "maximumLanguageVersion": "latest",
+          "parameters": [
+            {
+              "name": "str",
+              "type": "STRING",
+              "description": "The substring to be searched"
+            },
+            {
+              "name": "startIndex",
+              "type": "INTEGER",
+              "description": "The starting position for the search."
+            }
+          ],
+          "returns": [
+            {
+              "type": "INTEGER",
+              "description": "The starting index of the substring."
+            }
+          ]
+        },
+        {
+          "name": "getLength",
+          "description": "Returns the length of the current string.",
+          "documentation": "c_fgl_datatypes_STRING_getLength.html",
+          "minimumLanguageVersion": "none",
+          "maximumLanguageVersion": "latest",
+          "returns": [
+            {
+              "type": "INTEGER",
+              "description": "Length of string."
+            }
+          ]
+        },
+        {
+          "name": "subString",
+          "description": "Returns a substring from start and end positions in a given string.",
+          "documentation": "c_fgl_datatypes_STRING_subString.html",
+          "minimumLanguageVersion": "none",
+          "maximumLanguageVersion": "latest",
+          "parameters": [
+            {
+              "name": "startIndex",
+              "type": "INTEGER",
+              "description": "The starting position of the substring."
+            },
+            {
+              "name": "endIndex",
+              "type": "INTEGER",
+              "description": "The ending position of the substring."
+            }
+          ],
+          "returns": [
+            {
+              "type": "STRING",
+              "description": "The substring of the string."
+            }
+          ]
+        },
+        {
+          "name": "toLowerCase",
+          "description": "Returns the string converted to lower case.",
+          "documentation": "c_fgl_datatypes_STRING_toLowerCase.html",
+          "minimumLanguageVersion": "none",
+          "maximumLanguageVersion": "latest",
+          "returns": [
+            {
+              "type": "STRING",
+              "description": "Lowercased string."
+            }
+          ]
+        },
+        {
+          "name": "toUpperCase",
+          "description": "Returns the string converted to upper case.",
+          "documentation": "c_fgl_datatypes_STRING_toUpperCase.html",
+          "minimumLanguageVersion": "none",
+          "maximumLanguageVersion": "latest",
+          "returns": [
+            {
+              "type": "STRING",
+              "description": "Uppercased string."
+            }
+          ]
+        },
+        {
+          "name": "trim"
+        },
+        {
+          "name": "trimWhiteSpace"
+        },
+        {
+          "name": "trimLeft"
+        },
+        {
+          "name": "trimLeftWhiteSpace"
+        },
+        {
+          "name": "trimRight"
+        },
+        {
+          "name": "trimRightWhitespace"
+        }
+      ]
+    },
+    {
+      "name": "TEXT"
+    },
+    {
+      "name": "DYNAMIC ARRAY"
+    },
+    {
+      "name": "DICTIONARY"
+    },
+    {
+      "name": "JAVA ARRAY"
+    }
+  ]
+}

--- a/extension/Resources/built-in_ui.4GLPackage.json
+++ b/extension/Resources/built-in_ui.4GLPackage.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "./GeneroPackageSchema.json",
+  "name": "ui",
+  "type": "built-in",
+  "classes": [
+    {
+      "name": "Interface"
+    },
+    {
+      "name": "Window",
+      "description": "The ui.Window class provides an interface to the window objects create with the OPEN WINDOW instruction.",
+      "documentation": "c_fgl_ClassWindow.html",
+      "minimumLanguageVersion": "none",
+      "maximumLanguageVersion": "latest",
+      "classMethods": [
+        {
+          "name": "forName",
+          "description": "Get a window object by name.",
+          "documentation": "c_fgl_ClassWindow_forName.html",
+          "minimumLanguageVersion": "none",
+          "maximumLanguageVersion": "latest",
+          "parameters": [
+            {
+              "name": "name",
+              "type": "STRING",
+              "description": "Defines the name of the window."
+            }
+          ],
+          "returns": [
+            {
+              "type": "ui.Window",
+              "description": "Window object."
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Form"
+    },
+    {
+      "name": "Dialog",
+      "description": "The ui.Dialog class provides a set of methods to configure, query and control the current interactive instruction.",
+      "documentation": "c_fgl_ClassDialog.html",
+      "minimumLanguageVersion": "none",
+      "maximumLanguageVersion": "latest",
+      "classMethods": [
+        {
+          "name": "createConstructByName",
+          "description": "Creates an ui.Dialog object to implement a dynamic CONSTRUCT BY NAME.",
+          "documentation": "c_fgl_ClassDialog_createConstructByName.html",
+          "minimumLanguageVersion": "none",
+          "maximumLanguageVersion": "latest",
+          "parameters": [
+            {
+              "name": "fields",
+              "description": "The list of form fields controlled by the dialog.",
+              "type": "DYNAMIC ARRAY OF RECORD",
+              "recordMembers": [
+                {
+                  "name": "name",
+                  "type": "STRING"
+                },
+                {
+                  "name": "type",
+                  "type": "STRING"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "ComboBox"
+    },
+    {
+      "name": "DragDrop"
+    }
+  ]
+}

--- a/extension/Resources/external_com.4GLPackage.json
+++ b/extension/Resources/external_com.4GLPackage.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "./GeneroPackageSchema.json",
+  "name": "com",
+  "type": "external",
+  "classes": [
+
+  ]
+}

--- a/extension/Resources/external_os.4GLPackage.json
+++ b/extension/Resources/external_os.4GLPackage.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "./GeneroPackageSchema.json",
+  "name": "os",
+  "type": "external",
+  "description": "",
+  "documentation": "c_fgl_Class_os.html",
+  "minimumLanguageVersion": "none",
+  "maximumLanguageVersion": "latest",
+  "classes": [
+    {
+      "name": "Path",
+      "description": "The os.Path class provides functions to manipulate files and directories on the machine where the program executes.",
+      "documentation": "c_fgl_ext_os_path_001.html",
+      "minimumLanguageVersion": "none",
+      "maximumLanguageVersion": "latest",
+      "classMethods": [
+        {
+          "name": "atime",
+          "description": "Returns the time of the last file access.",
+          "documentation": "c_fgl_ext_os_path_atime.html",
+          "minimumLanguageVersion": "none",
+          "maximumLanguageVersion": "latest"
+        }
+      ]
+    }
+  ]
+}

--- a/extension/Resources/external_security.4GLPackage.json
+++ b/extension/Resources/external_security.4GLPackage.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "./GeneroPackageSchema.json",
+  "name": "security",
+  "type": "external",
+  "classes": [
+
+  ]
+}

--- a/extension/Resources/external_util.4GLPackage.json
+++ b/extension/Resources/external_util.4GLPackage.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "./GeneroPackageSchema.json",
+  "name": "util",
+  "type": "external",
+  "classes": [
+
+  ]
+}

--- a/extension/Resources/external_xml.4GLPackage.json
+++ b/extension/Resources/external_xml.4GLPackage.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "./GeneroPackageSchema.json",
+  "name": "xml",
+  "type": "external",
+  "classes": [
+
+  ]
+}

--- a/extension/package.json
+++ b/extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "Genero-FGL",
   "icon": "images/tiptop.ico",
   "description": "An essential tool designed to empower developers with a smooth and enjoyable experience when editing TIPTOP source code using Genero 4GL.",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "publisher": "m121752332",
   "repository": {
     "type": "git",
@@ -100,6 +100,14 @@
           "type": "boolean",
           "default": true,
           "description": "If true, normalize keywords to uppercase (only affects keyword tokens)."
+        },
+        "GeneroFGL.4gl.library.paths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Public library paths (file or directory). Workspace symbol search prioritizes these paths in order."
         },
         "GeneroFGL.4gl.definition.enable": {
           "type": "boolean",
@@ -425,6 +433,7 @@
     "esbuild-base": "esbuild ./src/extension.ts --bundle --outfile=out/main.js --external:vscode --format=cjs --platform=node",
     "esbuild": "npm run esbuild-base -- --sourcemap",
     "esbuild-watch": "npm run esbuild-base -- --sourcemap --watch",
+    "esbuild-lsp": "esbuild ./src/extension.ts --bundle --outfile=out/main.js --external:vscode --format=cjs --platform=node --sourcemap && esbuild ./src/server.ts --bundle --outfile=out/server.js --format=cjs --platform=node --sourcemap",
     "test-compile": "tsc -p ./",
     "test": "mocha -r ts-node/register --recursive unittests --reporter spec",
     "build-and-package": "node ./scripts/build-and-package.js",
@@ -447,7 +456,11 @@
   },
   "dependencies": {
     "vscode-languageclient": "8.1.0",
-    "@types/vscode": "^1.72.0"
+    "@types/vscode": "^1.72.0",
+    "vscode-languageserver": "^8.1.0",
+    "vscode-languageserver-textdocument": "^1.0.11",
+    "vscode-uri": "^2.1.1",
+    "request": "^2.88.0"
   },
   "dummy": {}
 }

--- a/extension/src/Handlers/importHandler.ts
+++ b/extension/src/Handlers/importHandler.ts
@@ -1,0 +1,234 @@
+import * as vscode from "vscode";
+import { Package, PackageClass, Method } from "./packageHandler";
+import { ImportType } from "./importTypes";
+
+export function getImportList(document: vscode.TextDocument) {
+    let importList: ImportType[] = [];
+    let commentBlock: boolean = false;
+    let endImports: RegExp = new RegExp("^\\s*(public|private|define|type|constant|function|main|report|options|&define|&include)\\b", "i");
+    let commentPosition: number = -1;
+    let importSection: string = "";
+
+    for (let i = 0; i < document.lineCount; i++) {
+        let line: string = document.lineAt(i).text.trim();
+
+        // Skip blank lines
+        if (!line.length) {
+            continue;
+        }
+
+        // Check for comment block ending
+        if (commentBlock) {
+            commentPosition = line.search("}");
+            if (commentPosition >= 0) {
+                commentBlock = false;
+                line = line.substring(commentPosition + 1).trim();
+                if (!line.length) {
+                    continue;
+                }
+            }
+        }
+
+        // Trim off any line comments
+        commentPosition = line.search("(--|#)");
+        if (commentPosition >= 0) {
+            line = line.substring(0, commentPosition).trim();
+            if (!line.length) {
+                continue;
+            }
+        }
+
+        // Check for comment block start
+        commentPosition = line.search("{");
+        if (commentPosition >= 0) {
+            commentBlock = true;
+            line = line.substring(0, commentPosition).trim();
+            if (!line.length) {
+                continue;
+            }
+        }
+
+        // Check for end of import range
+        let match: RegExpExecArray = endImports.exec(line);
+        if (match != null) {
+            break;
+        }
+
+        // At this point everything should be trimmed so we can just create a
+        // big string
+        importSection = `${importSection} ${line}`;
+    }
+
+    let imports: Array<string> = importSection.trim().split(new RegExp("\\bimport\\b", "i"));
+
+    imports.forEach(element => {
+        element = element.trim();
+        // Skip blank elements
+        if (!element.length) {
+            return;
+        }
+        let words: Array<string> = element.split(" ");
+        if (words[0].toLowerCase() == "fgl" || words[0].toLowerCase() == "java") {
+            importList.push({type: words[0], name: words[1]});
+        }
+        else {
+            importList.push({name: words[0]});
+        }
+    });
+
+    return importList;
+}
+
+function getChainInfo(document: vscode.TextDocument, position: vscode.Position) {
+    const line = document.lineAt(position.line).text;
+    const prefix = line.substring(0, position.character);
+
+    const trailingDotMatch = /([A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)*)\.$/.exec(prefix);
+    if (trailingDotMatch) {
+        const chain = trailingDotMatch[1];
+        const parts = chain.split(".");
+        return {
+            parts,
+            partial: "",
+            start: position.character,
+            end: position.character,
+            trailingDot: true
+        };
+    }
+
+    const match = /([A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)*)$/.exec(prefix);
+    if (!match) {
+        return null;
+    }
+
+    const chain = match[1];
+    const parts = chain.split(".");
+    const last = parts[parts.length - 1] || "";
+    const start = position.character - last.length;
+    return {
+        parts,
+        partial: last,
+        start,
+        end: position.character,
+        trailingDot: false
+    };
+}
+
+function matchesPrefix(name: string, prefix: string) {
+    if (!prefix) return true;
+    return name.toLowerCase().startsWith(prefix.toLowerCase());
+}
+
+function addCompletion(
+    items: vscode.CompletionItem[],
+    label: string,
+    kind: vscode.CompletionItemKind,
+    range: vscode.Range,
+    detail?: string,
+    documentation?: string
+) {
+    const item = new vscode.CompletionItem(label, kind);
+    item.range = range;
+    if (detail) item.detail = detail;
+    if (documentation) item.documentation = new vscode.MarkdownString(documentation);
+    items.push(item);
+}
+
+function getClassByName(pkg: Package, className: string): PackageClass | undefined {
+    return pkg.classes.find(c => c.name.toLowerCase() === className.toLowerCase());
+}
+
+function collectMethods(klass: PackageClass): Method[] {
+    const out: Method[] = [];
+    if (klass.objectMethods) out.push(...klass.objectMethods);
+    if (klass.classMethods) out.push(...klass.classMethods);
+    return out;
+}
+
+function buildMethodDetail(className: string, method: Method): string {
+    const params = (method.parameters || []).map(p => `${p.name}: ${p.type}`).join(", ");
+    return `${className}.${method.name}(${params})`;
+}
+
+export function importCompletion(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    imports: Package[]
+) {
+    let completions: vscode.CompletionItem[] = [];
+
+    const chain = getChainInfo(document, position);
+    if (!chain) return completions;
+
+    const range = new vscode.Range(position.line, chain.start, position.line, chain.end);
+
+    // No dot context: suggest packages and classes
+    if (chain.parts.length === 1 && !chain.trailingDot) {
+        const prefix = chain.partial;
+        const seen = new Set<string>();
+        for (const pkg of imports) {
+            if (matchesPrefix(pkg.name, prefix) && !seen.has(`pkg:${pkg.name}`)) {
+                addCompletion(completions, pkg.name, vscode.CompletionItemKind.Module, range, "package");
+                seen.add(`pkg:${pkg.name}`);
+            }
+            for (const klass of pkg.classes) {
+                if (matchesPrefix(klass.name, prefix) && !seen.has(`class:${klass.name}`)) {
+                    addCompletion(
+                        completions,
+                        klass.name,
+                        vscode.CompletionItemKind.Class,
+                        range,
+                        pkg.name,
+                        klass.description
+                    );
+                    seen.add(`class:${klass.name}`);
+                }
+            }
+        }
+        return completions;
+    }
+
+    const packageName = chain.parts[0];
+    const pkg = imports.find(p => p.name.toLowerCase() === packageName.toLowerCase());
+    if (!pkg) return completions;
+
+    // Package -> class completion
+    if (chain.parts.length === 2 && !chain.trailingDot) {
+        const prefix = chain.partial;
+        for (const klass of pkg.classes) {
+            if (matchesPrefix(klass.name, prefix)) {
+                addCompletion(
+                    completions,
+                    klass.name,
+                    vscode.CompletionItemKind.Class,
+                    range,
+                    pkg.name,
+                    klass.description
+                );
+            }
+        }
+        return completions;
+    }
+
+    // Package.Class -> method completion
+    const className = chain.parts[1];
+    const klass = getClassByName(pkg, className);
+    if (!klass) return completions;
+
+    const methodPrefix = chain.trailingDot ? "" : chain.partial;
+    const methods = collectMethods(klass);
+    for (const method of methods) {
+        if (matchesPrefix(method.name, methodPrefix)) {
+            addCompletion(
+                completions,
+                method.name,
+                vscode.CompletionItemKind.Method,
+                range,
+                buildMethodDetail(className, method),
+                method.description || method.documentation
+            );
+        }
+    }
+
+    return completions;
+}

--- a/extension/src/Handlers/importTypes.ts
+++ b/extension/src/Handlers/importTypes.ts
@@ -1,0 +1,4 @@
+export interface ImportType {
+  type?: string;
+  name: string;
+}

--- a/extension/src/Handlers/packageHandler.ts
+++ b/extension/src/Handlers/packageHandler.ts
@@ -1,0 +1,105 @@
+import * as fs from "fs";
+import * as path from "path";
+import { ImportType } from "./importTypes";
+
+export interface Package extends Info {
+    type: string;
+    classes: PackageClass[]
+}
+
+export interface PackageClass extends Info {
+    objectMethods?: Method[];
+    classMethods?: Method[];
+}
+
+export interface Method extends Info {
+    name: string;
+    parameters?: Parameter[];
+    returns?: Return[];
+}
+
+interface Info {
+    name: string;
+    description?: string;
+    documentation?: string;
+    minimumLanguageVersion?: string;
+    maximumLanguageVersion?: string;
+}
+
+interface Parameter {
+    name: string;
+    type: string;
+    description?: string;
+    recordMembers?: RecordMember[];
+}
+
+interface Return {
+    type: string;
+    description?: string;
+}
+
+interface RecordMember {
+    name: string;
+    type: string;
+    description?: string;
+}
+
+const PACKAGE_FILES: Record<string, string> = {
+    base: "built-in_base.4GLPackage.json",
+    datatypes: "built-in_dataTypes.4GLPackage.json",
+    ui: "built-in_ui.4GLPackage.json",
+    com: "external_com.4GLPackage.json",
+    os: "external_os.4GLPackage.json",
+    security: "external_security.4GLPackage.json",
+    util: "external_util.4GLPackage.json",
+    xml: "external_xml.4GLPackage.json"
+};
+
+const PACKAGE_CACHE = new Map<string, Package>();
+
+export function parsePackageClasses(importList: ImportType[]) {
+    let importPackages: Package[] = [];
+    importList.forEach(importItem => {
+        if (importItem.type == "fgl" || importItem.name == "java") {
+            return;
+        }
+        let importPackage: Package = whatPackage(importItem.name);
+        if (importPackage == null) {
+            return;
+        }
+        try {
+            importPackages.push(importPackage);
+        } catch (error) {
+            console.log(error);
+        }
+    });
+    return importPackages;
+}
+
+function whatPackage(packageName: string) {
+    const key = (packageName || "").toLowerCase();
+    if (PACKAGE_CACHE.has(key)) return PACKAGE_CACHE.get(key);
+
+    const fileName = PACKAGE_FILES[key];
+    if (!fileName) return null;
+
+    const candidates = [
+        path.join(__dirname, "..", "Resources", fileName),
+        path.join(__dirname, "..", "..", "Resources", fileName)
+    ];
+    const p = candidates.find(fp => fs.existsSync(fp));
+    if (!p) return null;
+
+    try {
+        const raw = fs.readFileSync(p, "utf8");
+        const json = JSON.parse(raw) as Package;
+        if (json && json.classes) {
+            PACKAGE_CACHE.set(key, json);
+            return json;
+        }
+    } catch (err) {
+        console.error("[Genero FGL] Failed to load package definition", p, err);
+    }
+
+    return null;
+}

--- a/extension/src/extension.ts
+++ b/extension/src/extension.ts
@@ -3,6 +3,11 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { parseSymbols, Sym } from './parser';
 import * as formatter from './formatter';
+import { CompletionProvider } from './providers/completionProvider';
+import { HoverProvider } from './providers/hoverProvider';
+import { WorkspaceSymbolProvider } from './providers/workspaceSymbolProvider';
+import { LanguageClient, LanguageClientOptions, ServerOptions, TransportKind } from 'vscode-languageclient/node';
+import { getPrioritizedFiles } from './utils/searchUtils';
 
 // Clean, single-file implementation for DocumentSymbols, DefinitionProvider
 // and unused-variable diagnostics for Genero 4GL.
@@ -375,20 +380,51 @@ function isDiagnosticEnabled(): boolean { const cfg = vscode.workspace.getConfig
 function getDiagnosticDelay(): number { const cfg = vscode.workspace.getConfiguration('GeneroFGL'); return cfg.get('4gl.diagnostic.delay', 500); }
 
 let diagnosticTimer: NodeJS.Timeout | undefined;
+let languageClient: LanguageClient | undefined;
 
 // --- Definition provider -------------------------------------------------
 class FourGLDefinitionProvider implements vscode.DefinitionProvider {
-  public async provideDefinition(document: vscode.TextDocument, position: vscode.Position): Promise<vscode.Location | null> {
+  public async provideDefinition(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): Promise<vscode.Location | null> {
     const wr = document.getWordRangeAtPosition(position, /[A-Za-z0-9_\.]+/);
     if (!wr) return null;
     const word = document.getText(wr);
 
+    // 1. Search in current file first
     const local = this.findDefinitionInText(document.getText(), word, document.uri);
     if (local) return local;
 
+    // 2. Search in prioritized library files/paths
+    //    這一步是效能優化的關鍵：若在優先目錄找到，立即返回，不再掃描整個工作區
+    const prioritizedFiles = await getPrioritizedFiles(token, ['.4gl']);
+    const checkedFiles = new Set<string>();
+
+    // Add current file to checked to avoid re-checking
+    checkedFiles.add(document.uri.toString());
+
+    for (const f of prioritizedFiles) {
+      if (token.isCancellationRequested) return null;
+      if (checkedFiles.has(f.toString())) continue;
+
+      try {
+        const doc = await vscode.workspace.openTextDocument(f);
+        const def = this.findDefinitionInText(doc.getText(), word, f);
+        if (def) {
+            checkedFiles.add(f.toString()); // 標記為已檢查
+            return def; // Early Exit!
+        }
+        checkedFiles.add(f.toString());
+      } catch (err) {
+        console.error(`[Genero FGL] Error searching definition in ${f.fsPath}`, err);
+      }
+    }
+
+    // 3. Search in remaining workspace files
+    //    只在前面兩步都找不到時才執行，且排除已檢查過的優先檔案
     const files = await vscode.workspace.findFiles('**/*.4gl');
     for (const f of files) {
-      if (f.toString() === document.uri.toString()) continue;
+      if (token.isCancellationRequested) return null;
+      if (checkedFiles.has(f.toString())) continue; // Skip if already checked in prioritized list or is current file
+
       try {
         const doc = await vscode.workspace.openTextDocument(f);
         const def = this.findDefinitionInText(doc.getText(), word, f);
@@ -413,11 +449,14 @@ class FourGLDefinitionProvider implements vscode.DefinitionProvider {
 export function activate(context: vscode.ExtensionContext) {
   console.log('[Genero FGL] activating');
 
+  const cfg = vscode.workspace.getConfiguration('GeneroFGL');
+  const lsEnabled = cfg.get('4gl.language-server.enable', false);
+  const completionEnabled4gl = cfg.get('4gl.completion.enable', true);
+  const completionEnabledPer = cfg.get('per.completion.enable', true);
+
   // If the experimental language-server setting is enabled, check that
   // a language server binary / script exists in the extension folder.
   try {
-    const cfg = vscode.workspace.getConfiguration('GeneroFGL');
-    const lsEnabled = cfg.get('4gl.language-server.enable', false);
     if (lsEnabled) {
       const extRoot = context.extensionPath || '';
       const candidates = [
@@ -433,6 +472,41 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.window.showWarningMessage('Genero FGL: language server enabled but no server files found in the extension bundle. Language server features will be unavailable.');
       } else {
         console.log('[Genero FGL] language server candidate found at', found);
+
+        const lspDebugBreak = process && process.env && process.env.FGL_LSP_DEBUG === '1';
+        const lspExecArgv = lspDebugBreak
+          ? ['--nolazy', '--inspect-brk=6009']
+          : ['--nolazy', '--inspect=6009'];
+        const serverOptions: ServerOptions = {
+          run: { module: found, transport: TransportKind.ipc, options: { execArgv: lspExecArgv } },
+          debug: {
+            module: found,
+            transport: TransportKind.ipc,
+            options: { execArgv: lspExecArgv }
+          }
+        };
+        const localCompletionProvider = new CompletionProvider();
+        const clientOptions: LanguageClientOptions = {
+          documentSelector: [{ language: '4gl' }, { language: 'per' }],
+          synchronize: { configurationSection: 'GeneroFGL' },
+          middleware: {
+            provideCompletionItem: async (document, position, completionContext, token, next) => {
+              console.log('[Client] provideCompletionItem middleware called for', document.uri.toString(), 'at', position);
+              const result = await next(document, position, completionContext, token);
+              console.log('[Client] LSP returned:', result ? (Array.isArray(result) ? result.length + ' items' : 'CompletionList with ' + result.items?.length + ' items') : 'null/undefined');
+              const isEmptyArray = Array.isArray(result) && result.length === 0;
+              const isEmptyList = !Array.isArray(result) && result && Array.isArray(result.items) && result.items.length === 0;
+              if (!result || isEmptyArray || isEmptyList) {
+                console.log('[Client] LSP returned empty, using local fallback');
+                return localCompletionProvider.provideCompletionItems(document, position);
+              }
+              return result;
+            }
+          }
+        };
+        languageClient = new LanguageClient('genero-fgl-lsp', 'Genero FGL Language Server', serverOptions, clientOptions);
+        languageClient.start();
+        context.subscriptions.push({ dispose: () => languageClient && languageClient.stop() });
       }
     }
   } catch (err) {
@@ -441,6 +515,19 @@ export function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(vscode.languages.registerDocumentSymbolProvider({ language: '4gl' }, { provideDocumentSymbols(document: vscode.TextDocument) { return parseDocumentSymbols(document.getText()); } }));
   context.subscriptions.push(vscode.languages.registerDefinitionProvider({ language: '4gl' }, new FourGLDefinitionProvider()));
+  context.subscriptions.push(vscode.languages.registerHoverProvider({ language: '4gl' }, new HoverProvider()));
+  context.subscriptions.push(vscode.languages.registerHoverProvider({ language: 'per' }, new HoverProvider()));
+  context.subscriptions.push(vscode.languages.registerWorkspaceSymbolProvider(new WorkspaceSymbolProvider()));
+
+  // Register completion providers for both 4GL and PER files (fallback when LSP is disabled)
+  // Use trigger characters so keywords suggest on typing (e.g., "L" -> "LET").
+  const completionTriggers = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_'.split('');
+  if (!lsEnabled && completionEnabled4gl) {
+    context.subscriptions.push(vscode.languages.registerCompletionItemProvider({ language: '4gl' }, new CompletionProvider(), ...completionTriggers));
+  }
+  if (!lsEnabled && completionEnabledPer) {
+    context.subscriptions.push(vscode.languages.registerCompletionItemProvider({ language: 'per' }, new CompletionProvider(), ...completionTriggers));
+  }
 
   // Register formatting providers
   const docFormatter: vscode.DocumentFormattingEditProvider = {
@@ -569,12 +656,12 @@ export function activate(context: vscode.ExtensionContext) {
   const onOpen = vscode.workspace.onDidOpenTextDocument(doc => { if (doc.languageId === '4gl' && isDiagnosticEnabled()) diagProvider.updateDiagnostics(doc); });
   context.subscriptions.push(onOpen);
 
-  const cfg = vscode.workspace.onDidChangeConfiguration(ev => {
+  const cfgListener = vscode.workspace.onDidChangeConfiguration(ev => {
     if (ev.affectsConfiguration('GeneroFGL.4gl.diagnostic')) {
       vscode.workspace.textDocuments.forEach(d => { if (d.languageId === '4gl') { if (isDiagnosticEnabled()) diagProvider.updateDiagnostics(d); else diagProvider.clearDiagnostics(d.uri); } });
     }
   });
-  context.subscriptions.push(cfg);
+  context.subscriptions.push(cfgListener);
 
   // initial run
   vscode.workspace.textDocuments.forEach(d => { if (d.languageId === '4gl' && isDiagnosticEnabled()) diagProvider.updateDiagnostics(d); });
@@ -586,4 +673,9 @@ export function activate(context: vscode.ExtensionContext) {
   console.log('[Genero FGL] activated');
 }
 
-export function deactivate() {}
+export function deactivate() {
+  if (languageClient) {
+    languageClient.stop();
+    languageClient = undefined;
+  }
+}

--- a/extension/src/providers/completionProvider.ts
+++ b/extension/src/providers/completionProvider.ts
@@ -1,0 +1,91 @@
+import * as vscode from 'vscode';
+import { KEYWORDS_4GL, KEYWORDS_PER } from './keywords';
+import { getImportList, importCompletion } from '../Handlers/importHandler';
+import { parsePackageClasses } from '../Handlers/packageHandler';
+
+export class CompletionProvider implements vscode.CompletionItemProvider {
+  public provideCompletionItems(
+    document: vscode.TextDocument,
+    position: vscode.Position
+  ): vscode.CompletionItem[] {
+    const line = document.lineAt(position.line).text;
+    const linePrefix = line.substring(0, position.character);
+
+    // 檢測語言
+    const isPerFile = document.languageId === 'per' || document.fileName.endsWith('.per');
+    const keywords = isPerFile ? KEYWORDS_PER : KEYWORDS_4GL;
+
+    // 提取當前輸入的單詞 - 從末尾向後查找
+    let wordStart = position.character - 1;
+    while (wordStart >= 0 && /[A-Za-z0-9_]/.test(line[wordStart])) {
+      wordStart--;
+    }
+    wordStart++;
+
+    const word = line.substring(wordStart, position.character);
+    const wordLower = word.toLowerCase();
+
+    // 計算單詞的 Range
+    const wordRange = new vscode.Range(position.line, wordStart, position.line, position.character);
+
+    // 過濾匹配用戶輸入的補全項
+    const completions: vscode.CompletionItem[] = [];
+
+    keywords.forEach((kw) => {
+      // 如果關鍵字以用戶輸入開頭，則包含在補全列表中
+      if (kw.name.toLowerCase().startsWith(wordLower)) {
+        const item = new vscode.CompletionItem(
+          kw.name,
+          this.mapCompletionKind(kw.type)
+        );
+        item.filterText = kw.name.toLowerCase();
+        item.sortText = kw.name.toLowerCase();
+        item.insertText = kw.name;
+        item.range = wordRange;
+        if (kw.documentation) {
+          item.documentation = new vscode.MarkdownString(kw.documentation);
+        }
+        completions.push(item);
+      }
+    });
+
+    // 套件/類別補全（匯入分析）
+    try {
+      const importList = getImportList(document);
+      importList.push({ name: 'dataTypes' }, { name: 'base' }, { name: 'ui' });
+      const importPackages = parsePackageClasses(importList);
+      const packageCompletions = importCompletion(document, position, importPackages);
+      for (const item of packageCompletions) {
+        const key = `${item.label}:${item.kind}`;
+        if (!completions.some(c => `${c.label}:${c.kind}` === key)) {
+          completions.push(item);
+        }
+      }
+    } catch (err) {
+      console.error('[Genero FGL] completion package analysis failed', err);
+    }
+
+    return completions;
+  }
+
+  private mapCompletionKind(type?: string): vscode.CompletionItemKind {
+    switch ((type || '').toLowerCase()) {
+      case 'keyword':
+        return vscode.CompletionItemKind.Keyword;
+      case 'color':
+        return vscode.CompletionItemKind.Color;
+      case 'constant':
+        return vscode.CompletionItemKind.Constant;
+      case 'variable':
+        return vscode.CompletionItemKind.Variable;
+      case 'operator':
+        return vscode.CompletionItemKind.Operator;
+      case 'method':
+        return vscode.CompletionItemKind.Method;
+      case 'function':
+        return vscode.CompletionItemKind.Function;
+      default:
+        return vscode.CompletionItemKind.Text;
+    }
+  }
+}

--- a/extension/src/providers/hoverProvider.ts
+++ b/extension/src/providers/hoverProvider.ts
@@ -1,0 +1,38 @@
+import * as vscode from 'vscode';
+import { KEYWORDS_4GL, KEYWORDS_PER } from './keywords';
+
+export class HoverProvider implements vscode.HoverProvider {
+  public provideHover(
+    document: vscode.TextDocument,
+    position: vscode.Position
+  ): vscode.Hover | null {
+    const range = document.getWordRangeAtPosition(position, /[A-Za-z0-9_]+/);
+    if (!range) return null;
+
+    const word = document.getText(range);
+    const isPerFile = document.languageId === 'per' || document.fileName.endsWith('.per');
+    const keywords = isPerFile ? KEYWORDS_PER : KEYWORDS_4GL;
+
+    const keyword = keywords.find((k) => k.name.toLowerCase() === word.toLowerCase());
+    if (!keyword) return null;
+
+    const markdown = new vscode.MarkdownString();
+    markdown.appendCodeblock(keyword.name, 'genero 4gl');
+
+    if (keyword.description) {
+      markdown.appendMarkdown('\n\n');
+      markdown.appendMarkdown(keyword.description);
+    }
+
+    if (keyword.documentation) {
+      markdown.appendMarkdown('\n\n');
+      markdown.appendMarkdown(keyword.documentation);
+    }
+
+    if (keyword.type) {
+      markdown.appendMarkdown(`\n\n**Type**: ${keyword.type}`);
+    }
+
+    return new vscode.Hover(markdown);
+  }
+}

--- a/extension/src/providers/keywords.ts
+++ b/extension/src/providers/keywords.ts
@@ -1,0 +1,37 @@
+/**
+ * 關鍵字定義 - 用於補全和 Hover 功能（與 GeneroLSP 對齊）
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+interface KeywordItem {
+  name: string;
+  type?: string;
+  documentation?: string;
+  description?: string;
+}
+
+function loadKeywords(fileName: string): KeywordItem[] {
+  const candidates = [
+    path.join(__dirname, '..', 'Resources', fileName),
+    path.join(__dirname, '..', '..', 'Resources', fileName)
+  ];
+
+  const p = candidates.find(fp => fs.existsSync(fp));
+  if (!p) return [];
+
+  try {
+    const raw = fs.readFileSync(p, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) return parsed as KeywordItem[];
+    if (parsed && Array.isArray(parsed.keywords)) return parsed.keywords as KeywordItem[];
+  } catch (err) {
+    console.error('[Genero FGL] Failed to load keywords', fileName, err);
+  }
+
+  return [];
+}
+
+export const KEYWORDS_4GL: KeywordItem[] = loadKeywords('4GLKeywords.json');
+export const KEYWORDS_PER: KeywordItem[] = loadKeywords('PERKeywords.json');

--- a/extension/src/providers/workspaceSymbolProvider.ts
+++ b/extension/src/providers/workspaceSymbolProvider.ts
@@ -1,0 +1,256 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+import { parseSymbols, Sym } from '../parser';
+import { getPrioritizedFiles } from '../utils/searchUtils';
+
+/**
+ * WorkspaceSymbolProvider - 在整個工作區中搜索符號（函數、報表、RECORD、TYPE）
+ * 允許使用 Ctrl+T 快速定位跨文件的符號
+ */
+export class WorkspaceSymbolProvider implements vscode.WorkspaceSymbolProvider {
+  /**
+   * 提供工作區符號搜索
+   * @param query 搜索查詢字符串（函數名、報表名等）
+   */
+  public async provideWorkspaceSymbols(
+    query: string,
+    token: vscode.CancellationToken
+  ): Promise<vscode.SymbolInformation[]> {
+    const symbols: vscode.SymbolInformation[] = [];
+
+    try {
+      // 1. 獲取優先搜尋的庫文件
+      const prioritizedFiles = await getPrioritizedFiles(token, ['.4gl', '.per']);
+
+      // 2. 搜尋其餘工作區文件
+      const workspaceFiles = await vscode.workspace.findFiles('**/*.{4gl,per}');
+
+      // 3. 合併並去重
+      const files = this.mergeUniqueFiles(prioritizedFiles, workspaceFiles);
+
+      for (const fileUri of files) {
+        if (token.isCancellationRequested) break;
+
+        try {
+          const document = await vscode.workspace.openTextDocument(fileUri);
+          const fileSymbols = await this.extractSymbolsFromFile(
+            document,
+            query
+          );
+          symbols.push(...fileSymbols);
+        } catch (err) {
+          console.error(`[Genero FGL] Error parsing file ${fileUri.fsPath}:`, err);
+        }
+      }
+    } catch (err) {
+      console.error('[Genero FGL] Error in workspace symbol search:', err);
+    }
+
+    return symbols;
+  }
+
+  private mergeUniqueFiles(
+    prioritizedFiles: vscode.Uri[],
+    workspaceFiles: vscode.Uri[]
+  ): vscode.Uri[] {
+    const seen = new Set<string>();
+    const result: vscode.Uri[] = [];
+
+    // 先加入優先文件
+    for (const uri of prioritizedFiles) {
+      const key = uri.fsPath.toLowerCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+      result.push(uri);
+    }
+
+    // 再加入工作區其他文件
+    for (const uri of workspaceFiles) {
+      const key = uri.fsPath.toLowerCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+      result.push(uri);
+    }
+
+    return result;
+  }
+
+  /**
+   * 從單個文件中提取符號
+   */
+  private async extractSymbolsFromFile(
+    document: vscode.TextDocument,
+    query: string
+  ): Promise<vscode.SymbolInformation[]> {
+    const symbols: vscode.SymbolInformation[] = [];
+    const text = document.getText();
+    const lines = text.split(/\r?\n/);
+
+    // 解析文檔符號
+    try {
+      const parsed = parseSymbols(text);
+      this.collectSymbols(parsed, symbols, document.uri, query);
+    } catch (err) {
+      console.error(`[Genero FGL] Symbol parsing error for ${document.uri.fsPath}:`, err);
+    }
+
+    // 備用：簡單的正則表達式搜索（如果解析失敗）
+    if (symbols.length === 0) {
+      const functionRegex = /^\s*(?:PUBLIC|PRIVATE|STATIC)?\s*FUNCTION\s+([A-Za-z0-9_]+)/im;
+      const reportRegex = /^\s*REPORT\s+([A-Za-z0-9_]+)/im;
+      const typeRegex = /^\s*TYPE\s+([A-Za-z0-9_]+)/im;
+      const recordRegex = /^\s*(?:.*?)\s+([A-Za-z0-9_]+)\s+(?:DYNAMIC\s+ARRAY\s+OF\s+)?RECORD\b/im;
+
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+
+        // 搜索函數
+        let match = functionRegex.exec(line);
+        if (match && this.matchesQuery(match[1], query)) {
+          symbols.push(
+            new vscode.SymbolInformation(
+              match[1],
+              vscode.SymbolKind.Function,
+              '',
+              new vscode.Location(document.uri, new vscode.Position(i, 0))
+            )
+          );
+          functionRegex.lastIndex = 0;
+        }
+
+        // 搜索報表
+        match = reportRegex.exec(line);
+        if (match && this.matchesQuery(match[1], query)) {
+          symbols.push(
+            new vscode.SymbolInformation(
+              match[1],
+              vscode.SymbolKind.Function,
+              '',
+              new vscode.Location(document.uri, new vscode.Position(i, 0))
+            )
+          );
+          reportRegex.lastIndex = 0;
+        }
+
+        // 搜索 TYPE
+        match = typeRegex.exec(line);
+        if (match && this.matchesQuery(match[1], query)) {
+          symbols.push(
+            new vscode.SymbolInformation(
+              match[1],
+              vscode.SymbolKind.Struct,
+              '',
+              new vscode.Location(document.uri, new vscode.Position(i, 0))
+            )
+          );
+          typeRegex.lastIndex = 0;
+        }
+
+        // 搜索 RECORD
+        match = recordRegex.exec(line);
+        if (match && this.matchesQuery(match[1], query)) {
+          symbols.push(
+            new vscode.SymbolInformation(
+              match[1],
+              vscode.SymbolKind.Struct,
+              '',
+              new vscode.Location(document.uri, new vscode.Position(i, 0))
+            )
+          );
+          recordRegex.lastIndex = 0;
+        }
+      }
+    }
+
+    return symbols;
+  }
+
+  /**
+   * 遞迴收集符號
+   */
+  private collectSymbols(
+    syms: Sym[],
+    result: vscode.SymbolInformation[],
+    uri: vscode.Uri,
+    query: string
+  ): void {
+    for (const sym of syms) {
+      if (!sym.name) continue;
+
+      // 檢查是否匹配查詢
+      if (this.matchesQuery(sym.name, query)) {
+        let kind: vscode.SymbolKind = vscode.SymbolKind.Variable;
+        const symKind = (sym.kind || 'Variable') as string;
+        switch (symKind) {
+          case 'Function':
+            kind = vscode.SymbolKind.Function;
+            break;
+          case 'Report':
+            kind = vscode.SymbolKind.Function;
+            break;
+          case 'Record':
+            kind = vscode.SymbolKind.Struct;
+            break;
+          case 'Type':
+            kind = vscode.SymbolKind.Struct;
+            break;
+          case 'Main':
+            kind = vscode.SymbolKind.Namespace;
+            break;
+          case 'Globals':
+            kind = vscode.SymbolKind.Namespace;
+            break;
+          case 'Variable':
+          case 'ModuleVariable':
+            kind = vscode.SymbolKind.Variable;
+            break;
+        }
+
+        result.push(
+          new vscode.SymbolInformation(
+            sym.name,
+            kind,
+            sym.detail || '',
+            new vscode.Location(uri, new vscode.Position(sym.start, 0))
+          )
+        );
+      }
+
+      // 遞迴搜索子符號
+      if (sym.children && sym.children.length > 0) {
+        this.collectSymbols(sym.children, result, uri, query);
+      }
+    }
+  }
+
+  /**
+   * 檢查符號名是否匹配查詢
+   * 支持模糊匹配和前綴匹配
+   */
+  private matchesQuery(name: string, query: string): boolean {
+    if (!query || query.length === 0) return true;
+
+    const lowerName = name.toLowerCase();
+    const lowerQuery = query.toLowerCase();
+
+    // 完全匹配
+    if (lowerName === lowerQuery) return true;
+
+    // 前綴匹配
+    if (lowerName.startsWith(lowerQuery)) return true;
+
+    // 包含匹配（任意位置）
+    if (lowerName.includes(lowerQuery)) return true;
+
+    // 模糊匹配：查詢的每個字符都在名稱中按順序出現
+    let nameIndex = 0;
+    for (const char of lowerQuery) {
+      nameIndex = lowerName.indexOf(char, nameIndex);
+      if (nameIndex === -1) return false;
+      nameIndex++;
+    }
+
+    return true;
+  }
+}

--- a/extension/src/server.ts
+++ b/extension/src/server.ts
@@ -1,0 +1,362 @@
+import {
+  createConnection,
+  TextDocuments,
+  ProposedFeatures,
+  InitializeParams,
+  InitializeResult,
+  CompletionItem,
+  CompletionItemKind,
+  TextDocumentSyncKind
+} from 'vscode-languageserver/node';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+import { KEYWORDS_4GL, KEYWORDS_PER } from './providers/keywords';
+import { parsePackageClasses, Package, PackageClass, Method } from './Handlers/packageHandler';
+import { ImportType } from './Handlers/importTypes';
+
+const connection = createConnection(ProposedFeatures.all);
+const documents: TextDocuments<TextDocument> = new TextDocuments(TextDocument);
+
+console.log('[LSP Server] Starting Genero FGL Language Server');
+
+connection.onInitialize((params: InitializeParams): InitializeResult => {
+  console.log('[LSP Server] onInitialize called');
+  return {
+    capabilities: {
+      textDocumentSync: TextDocumentSyncKind.Incremental,
+      completionProvider: {
+        resolveProvider: false,
+        triggerCharacters: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_'.split('')
+      }
+    }
+  };
+});
+
+connection.onInitialized(() => {
+  console.log('[LSP Server] onInitialized - server is ready');
+});
+
+documents.onDidOpen((event) => {
+  console.log('[LSP Server] Document opened:', event.document.uri, 'languageId:', event.document.languageId);
+});
+
+documents.onDidChangeContent((change) => {
+  console.log('[LSP Server] Document changed:', change.document.uri);
+});
+
+function getKeywords(languageId: string): { name: string; type?: string; documentation?: string }[] {
+  if (languageId === 'per') return KEYWORDS_PER;
+  return KEYWORDS_4GL;
+}
+
+function getWordAtPosition(text: string, offset: number): { word: string; start: number; end: number } {
+  let start = offset;
+  let end = offset;
+  while (start > 0 && /[A-Za-z0-9_]/.test(text.charAt(start - 1))) {
+    start--;
+  }
+  while (end < text.length && /[A-Za-z0-9_]/.test(text.charAt(end))) {
+    end++;
+  }
+  return { word: text.substring(start, end), start, end };
+}
+
+function getImportListFromDocument(text: string): ImportType[] {
+  const importList: ImportType[] = [];
+  let commentBlock = false;
+  const endImports = new RegExp('^\\s*(public|private|define|type|constant|function|main|report|options|&define|&include)\\b', 'i');
+  let commentPosition = -1;
+  let importSection = '';
+
+  const lines = text.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    let line = lines[i].trim();
+
+    if (!line.length) {
+      continue;
+    }
+
+    if (commentBlock) {
+      commentPosition = line.search('}');
+      if (commentPosition >= 0) {
+        commentBlock = false;
+        line = line.substring(commentPosition + 1).trim();
+        if (!line.length) {
+          continue;
+        }
+      }
+    }
+
+    commentPosition = line.search('(--|#)');
+    if (commentPosition >= 0) {
+      line = line.substring(0, commentPosition).trim();
+      if (!line.length) {
+        continue;
+      }
+    }
+
+    commentPosition = line.search('{');
+    if (commentPosition >= 0) {
+      commentBlock = true;
+      line = line.substring(0, commentPosition).trim();
+      if (!line.length) {
+        continue;
+      }
+    }
+
+    const match = endImports.exec(line);
+    if (match != null) {
+      break;
+    }
+
+    importSection = `${importSection} ${line}`;
+  }
+
+  const imports: Array<string> = importSection.trim().split(new RegExp('\\bimport\\b', 'i'));
+
+  imports.forEach(element => {
+    element = element.trim();
+    if (!element.length) {
+      return;
+    }
+    const words: Array<string> = element.split(' ');
+    if (words[0].toLowerCase() === 'fgl' || words[0].toLowerCase() === 'java') {
+      importList.push({ type: words[0], name: words[1] });
+    } else {
+      importList.push({ name: words[0] });
+    }
+  });
+
+  return importList;
+}
+
+function getChainInfoFromLine(line: string, positionChar: number) {
+  const prefix = line.substring(0, positionChar);
+
+  const trailingDotMatch = /([A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)*)\.$/.exec(prefix);
+  if (trailingDotMatch) {
+    const chain = trailingDotMatch[1];
+    const parts = chain.split('.');
+    return {
+      parts,
+      partial: '',
+      start: positionChar,
+      end: positionChar,
+      trailingDot: true
+    };
+  }
+
+  const match = /([A-Za-z0-9_]+(?:\.[A-Za-z0-9_]+)*)$/.exec(prefix);
+  if (!match) {
+    return null;
+  }
+
+  const chain = match[1];
+  const parts = chain.split('.');
+  const last = parts[parts.length - 1] || '';
+  const start = positionChar - last.length;
+  return {
+    parts,
+    partial: last,
+    start,
+    end: positionChar,
+    trailingDot: false
+  };
+}
+
+function matchesPrefix(name: string, prefix: string) {
+  if (!prefix) return true;
+  return name.toLowerCase().startsWith(prefix.toLowerCase());
+}
+
+function buildMethodDetail(className: string, method: Method): string {
+  const params = (method.parameters || []).map(p => `${p.name}: ${p.type}`).join(', ');
+  return `${className}.${method.name}(${params})`;
+}
+
+function getClassByName(pkg: Package, className: string): PackageClass | undefined {
+  return pkg.classes.find(c => c.name.toLowerCase() === className.toLowerCase());
+}
+
+function collectMethods(klass: PackageClass): Method[] {
+  const out: Method[] = [];
+  if (klass.objectMethods) out.push(...klass.objectMethods);
+  if (klass.classMethods) out.push(...klass.classMethods);
+  return out;
+}
+
+function addCompletionItem(
+  items: CompletionItem[],
+  label: string,
+  kind: CompletionItemKind,
+  range: { start: { line: number; character: number }; end: { line: number; character: number } },
+  detail?: string,
+  documentation?: string
+) {
+  items.push({
+    label,
+    kind,
+    detail,
+    documentation,
+    textEdit: { range, newText: label }
+  });
+}
+
+function importCompletionLsp(
+  line: string,
+  position: { line: number; character: number },
+  imports: Package[]
+): CompletionItem[] {
+  const completions: CompletionItem[] = [];
+  const chain = getChainInfoFromLine(line, position.character);
+  if (!chain) return completions;
+
+  const range = {
+    start: { line: position.line, character: chain.start },
+    end: { line: position.line, character: chain.end }
+  };
+
+  if (chain.parts.length === 1 && !chain.trailingDot) {
+    const prefix = chain.partial;
+    const seen = new Set<string>();
+    for (const pkg of imports) {
+      if (matchesPrefix(pkg.name, prefix) && !seen.has(`pkg:${pkg.name}`)) {
+        addCompletionItem(completions, pkg.name, CompletionItemKind.Module, range, 'package');
+        seen.add(`pkg:${pkg.name}`);
+      }
+      for (const klass of pkg.classes) {
+        if (matchesPrefix(klass.name, prefix) && !seen.has(`class:${klass.name}`)) {
+          addCompletionItem(completions, klass.name, CompletionItemKind.Class, range, pkg.name, klass.description);
+          seen.add(`class:${klass.name}`);
+        }
+      }
+    }
+    return completions;
+  }
+
+  const packageName = chain.parts[0];
+  const pkg = imports.find(p => p.name.toLowerCase() === packageName.toLowerCase());
+  if (!pkg) return completions;
+
+  if (chain.parts.length === 2 && !chain.trailingDot) {
+    const prefix = chain.partial;
+    for (const klass of pkg.classes) {
+      if (matchesPrefix(klass.name, prefix)) {
+        addCompletionItem(completions, klass.name, CompletionItemKind.Class, range, pkg.name, klass.description);
+      }
+    }
+    return completions;
+  }
+
+  const className = chain.parts[1];
+  const klass = getClassByName(pkg, className);
+  if (!klass) return completions;
+
+  const methodPrefix = chain.trailingDot ? '' : chain.partial;
+  const methods = collectMethods(klass);
+  for (const method of methods) {
+    if (matchesPrefix(method.name, methodPrefix)) {
+      addCompletionItem(
+        completions,
+        method.name,
+        CompletionItemKind.Method,
+        range,
+        buildMethodDetail(className, method),
+        method.description || method.documentation
+      );
+    }
+  }
+
+  return completions;
+}
+
+connection.onCompletion((params): CompletionItem[] => {
+  try {
+    console.log('[LSP] ===== onCompletion CALLED =====', params.textDocument.uri, params.position);
+    const doc = documents.get(params.textDocument.uri);
+    if (!doc) {
+      console.log('[LSP] Document not found!');
+      return [];
+    }
+
+    const offset = doc.offsetAt(params.position);
+    const fullText = doc.getText();
+    const { word, start, end } = getWordAtPosition(fullText, offset);
+    const wordLower = word.toLowerCase();
+    const wordRange = {
+      start: doc.positionAt(start),
+      end: doc.positionAt(end)
+    };
+    const lines = fullText.split(/\r?\n/);
+    const lineText = lines[params.position.line] || '';
+
+    console.log('[LSP] Completion triggered - word:', word, 'wordLower:', wordLower, 'languageId:', doc.languageId);
+
+    const keywords = getKeywords(doc.languageId);
+    const items: CompletionItem[] = [];
+    const seen = new Set<string>();
+
+    for (const kw of keywords) {
+      const nameLower = kw.name.toLowerCase();
+      if (nameLower.startsWith(wordLower) || wordLower === '') {
+        const key = `${kw.name}:${kw.type || 'keyword'}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        items.push({
+          label: kw.name,
+          kind: mapCompletionKind(kw.type),
+          detail: kw.type,
+          documentation: kw.documentation,
+          textEdit: { range: wordRange, newText: kw.name }
+        });
+      }
+    }
+
+    try {
+      const importList = getImportListFromDocument(fullText);
+      importList.push({ name: 'dataTypes' }, { name: 'base' }, { name: 'ui' });
+      const importPackages = parsePackageClasses(importList);
+      const packageItems = importCompletionLsp(lineText, params.position, importPackages);
+      for (const item of packageItems) {
+        const key = `${item.label}:${item.kind}`;
+        if (!seen.has(key)) {
+          seen.add(key);
+          items.push(item);
+        }
+      }
+    } catch (err) {
+      console.error('[LSP] Package completion failed', err);
+    }
+
+    console.log('[LSP] Returning', items.length, 'completion items, first 3:', items.slice(0, 3).map(i => i.label));
+    return items;
+  } catch (err) {
+    console.error('[LSP] FATAL: onCompletion crashed:', err);
+    return [];
+  }
+});
+
+function mapCompletionKind(type?: string): CompletionItemKind {
+  switch ((type || '').toLowerCase()) {
+    case 'keyword':
+      return CompletionItemKind.Keyword;
+    case 'color':
+      return CompletionItemKind.Color;
+    case 'constant':
+      return CompletionItemKind.Constant;
+    case 'variable':
+      return CompletionItemKind.Variable;
+    case 'operator':
+      return CompletionItemKind.Operator;
+    case 'method':
+      return CompletionItemKind.Method;
+    case 'function':
+      return CompletionItemKind.Function;
+    default:
+      return CompletionItemKind.Text;
+  }
+}
+
+documents.listen(connection);
+connection.listen();
+
+console.log('[LSP Server] Now listening for requests...');

--- a/extension/src/utils/searchUtils.ts
+++ b/extension/src/utils/searchUtils.ts
@@ -1,0 +1,98 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const SUPPORTED_EXTENSIONS = new Set(['.4gl', '.per']);
+
+function isSupportedFile(filePath: string): boolean {
+  const ext = path.extname(filePath).toLowerCase();
+  return SUPPORTED_EXTENSIONS.has(ext);
+}
+
+async function walkDirectoryForFiles(
+  dirPath: string,
+  token: vscode.CancellationToken
+): Promise<vscode.Uri[]> {
+  const files: vscode.Uri[] = [];
+  try {
+    const entries = await fs.promises.readdir(dirPath, { withFileTypes: true });
+    for (const entry of entries) {
+      if (token.isCancellationRequested) break;
+      const fullPath = path.join(dirPath, entry.name);
+      if (entry.isDirectory()) {
+        const childFiles = await walkDirectoryForFiles(fullPath, token);
+        files.push(...childFiles);
+      } else if (entry.isFile() && isSupportedFile(fullPath)) {
+        files.push(vscode.Uri.file(fullPath));
+      }
+    }
+  } catch (err) {
+    console.error(`[Genero FGL] Error scanning library directory ${dirPath}:`, err);
+  }
+  return files;
+}
+
+/**
+ * 獲取優先搜尋的檔案列表
+ * 根據 GeneroFGL.4gl.library.paths 設定
+ */
+export async function getPrioritizedFiles(
+  token: vscode.CancellationToken,
+  extensions?: string[]
+): Promise<vscode.Uri[]> {
+  const cfg = vscode.workspace.getConfiguration('GeneroFGL');
+  const libraryPaths = cfg.get<string[]>('4gl.library.paths', []) || [];
+  if (!Array.isArray(libraryPaths) || libraryPaths.length === 0) return [];
+
+  const workspaceRoots = vscode.workspace.workspaceFolders?.map(folder => folder.uri.fsPath) || [];
+  const resolvedPaths: string[] = [];
+
+  for (const raw of libraryPaths) {
+    const p = (raw || '').trim();
+    if (!p) continue;
+
+    // 處理相對路徑與絕對路徑
+    if (path.isAbsolute(p)) {
+      resolvedPaths.push(p);
+    } else {
+      for (const root of workspaceRoots) {
+        resolvedPaths.push(path.join(root, p));
+      }
+    }
+  }
+
+  // 如果有指定副檔名，暫時過濾掉集合
+  const targetExts = extensions ? new Set(extensions.map(e => e.toLowerCase())) : SUPPORTED_EXTENSIONS;
+
+  const files: vscode.Uri[] = [];
+  const seenPaths = new Set<string>();
+
+  for (const p of resolvedPaths) {
+    if (token.isCancellationRequested) break;
+    if (!fs.existsSync(p)) continue;
+
+    try {
+      const stat = fs.statSync(p);
+      if (stat.isFile()) {
+        const ext = path.extname(p).toLowerCase();
+        if (targetExts.has(ext) && !seenPaths.has(p)) {
+          files.push(vscode.Uri.file(p));
+          seenPaths.add(p);
+        }
+      } else if (stat.isDirectory()) {
+        const dirFiles = await walkDirectoryForFiles(p, token);
+        for (const uri of dirFiles) {
+          const ext = path.extname(uri.fsPath).toLowerCase();
+          if (targetExts.has(ext) && !seenPaths.has(uri.fsPath)) {
+            files.push(uri);
+            seenPaths.add(uri.fsPath);
+          }
+        }
+      }
+    } catch (err) {
+      console.error(`[Genero FGL] Error reading library path ${p}:`, err);
+    }
+  }
+
+  return files;
+}


### PR DESCRIPTION
# 新增LSP功能

## 變更摘要 (Summary)

本次更新新增了LSP實作，並為了解決在大型工作區中「移至定義 (F12)」與「工作區符號搜尋 (Ctrl+T)」效能低落的問題。
新增了優先搜尋路徑的設定，並重構了搜尋邏輯以支援「優先路徑先決 (First-match wins)」策略。

## 修改內容 (Changes Detail)

1. 新增設定項：GeneroFGL.4gl.library.paths
新增支援設定公用 Library 路徑（字串陣列）。
支援 絕對路徑 與 相對路徑 (相對於工作區根目錄)。
支援指定 特定檔案 或 整個目錄 (遞迴搜尋)。

2. 新增工具模組：src/utils/searchUtils.ts
抽離共用的檔案搜尋邏輯，統一處理路徑解析、遞迴掃描與 .4gl/.per 檔案過濾。
提供 getPrioritizedFiles 方法供各 Provider 重用。

3. 優化「移至定義 (F12)」：extension.ts
重構 FourGLDefinitionProvider：
優先掃描：優先搜尋 library.paths 設定的路徑。
Early Exit 機制：一旦在優先路徑中找到定義，立即返回結果，不再對整個工作區進行全域掃描。
排除重複：若優先路徑未找到，進行全域掃描時會自動排除已檢查過的 Library 檔案。
效益：顯著提升在大型專案中跳轉至公用涵式時的速度。

4. 優化「工作區符號搜尋 (Ctrl+T)」：workspaceSymbolProvider.ts
改用新的 searchUtils 獲取檔案列表。
調整搜尋順序：優先處理 Library 路徑中的符號，確保其在搜尋結果中排在較前位置，並過濾重複掃描的檔案。

5. 程式碼整理
在 activate 函式中，將分散的 lsEnabled (Language Server 啟用檢查) 邏輯區塊合併，使啟動流程更清晰。
測試與驗證 (Verification)
 設定 GeneroFGL.4gl.library.paths 指向常用 lib 目錄。
 按下 F12 跳轉至 lib 中的涵式，確認速度提升且能正確跳轉。
 使用 Ctrl+T 搜尋符號，確認 Library 中的符號能被正確索引。

6. LSP部份實作參考自 [daeghanelkin的GeneroLSP](https://github.com/daeghanelkin/GeneroLSP)
